### PR TITLE
Implement 'admin update table' command to call UpdateTable API for existing tables. Only mode and CU for now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,12 @@ FLAGS: ...
 OPTIONS: ...
 
 SUBCOMMANDS:
-    create    Create new DynamoDB table or GSI
-    delete    Delete a DynamoDB table or GSI
+    create    Create new DynamoDB table or GSI. [API: CreateTable, UpdateTable]
+    delete    Delete a DynamoDB table or GSI. [API: DeleteTable]
     desc      Show detailed information of a table. [API: DescribeTable]
     help      Prints this message or the help of the given subcommand(s)
     list      List tables in the region. [API: ListTables]
+    update    Update a DynamoDB table. [API: UpdateTable etc]
 ```
 
 By executing following command, you can create a DynamoDB table.
@@ -300,7 +301,7 @@ size_bytes: 0
 created_at: "2020-03-03T13:34:43+00:00"
 ```
 
-After the table get ready (= `ACTIVE` status), you can write-to and read-from the table.
+After the table get ready (i.e. `status: CREATING` changed to `ACTIVE`), you can write-to and read-from the table.
 
 ```
 $ dy use app_users
@@ -332,7 +333,7 @@ myapp   1234     {"rank":99}
 Similarly you can update tables with dynein.
 
 ```
-(currently not available) $ dy admin update table --mode provisioned --wcu 10 --rcu 25
+$ dy admin update table app_users --mode provisioned --wcu 10 --rcu 25
 ```
 
 
@@ -814,7 +815,6 @@ $ RUST_LOG=debug RUST_BACKTRACE=1 dy scan --table your_table
 
 ## Ideas for future works
 
-- `dy admin update table` command
 - `dy admin plan` & `dy admin apply` commands to manage tables through CloudFormation.
   - These subcommand names are inspired by [HashiCorp's Terraform](https://www.terraform.io/).
 - Linux's `top` -like experience to monitor table status. e.g. `dy top tables`
@@ -828,3 +828,4 @@ $ RUST_LOG=debug RUST_BACKTRACE=1 dy scan --table your_table
 - Support Transaction APIs (TransactGetItems, TransactWriteItems)
 - simple load testing. e.g. `dy load --tps 100`
 - import/export tool supports LTSV, TSV
+- PITR configuration enable/disable (UpdateContinuousBackups) and exporting/restoring tables ([ExportTableToPointInTime](https://aws.amazon.com/blogs/aws/new-export-amazon-dynamodb-table-data-to-data-lake-amazon-s3/), RestoreTableToPointInTime)

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -371,14 +371,21 @@ pub enum AdminSub {
         output: Option<String>,
     },
 
-    /// Create new DynamoDB table or GSI.
+    /// Create new DynamoDB table or GSI. [API: CreateTable, UpdateTable]
     #[structopt()]
     Create {
         #[structopt(subcommand)]
         target_type: CreateSub,
     },
 
-    /// Delete a DynamoDB table or GSI.
+    /// Update a DynamoDB table. [API: UpdateTable etc]
+    #[structopt()]
+    Update {
+        #[structopt(subcommand)]
+        target_type: UpdateSub,
+    },
+
+    /// Delete a DynamoDB table or GSI. [API: DeleteTable]
     #[structopt()]
     Delete {
         #[structopt(subcommand)]
@@ -415,7 +422,7 @@ pub enum AdminSub {
 #[derive(StructOpt, Debug, Serialize, Deserialize)]
 pub enum CreateSub {
 
-    /// Create new DynamoDB table with given primary key(s).
+    /// Create new DynamoDB table with given primary key(s). [API: CreateTable]
     #[structopt()]
     Table {
         /// table name to create
@@ -427,7 +434,7 @@ pub enum CreateSub {
         keys: Vec<String>,
     },
 
-    /// Create new GSI (global secondary index) for a table with given primary key(s).
+    /// Create new GSI (global secondary index) for a table with given primary key(s). [API: UpdateTable]
     #[structopt()]
     Index {
         /// index name to create
@@ -438,6 +445,37 @@ pub enum CreateSub {
         #[structopt(short, long, required = true)]
         keys: Vec<String>,
     }
+}
+
+
+#[derive(StructOpt, Debug, Serialize, Deserialize)]
+pub enum UpdateSub {
+
+    /// Update a DynamoDB table.
+    #[structopt()]
+    Table {
+        /// table name to update
+        table_name_to_update: String,
+
+        /// DynamoDB capacity mode. Availablle values: [provisioned, ondemand].
+        /// When you switch from OnDemand to Provisioned mode, you can pass WCU and RCU as well (NOTE: default capacity unit for Provisioned mode is 5).
+        #[structopt(short, long, possible_values = &["provisioned", "ondemand"])]
+        mode: Option<String>,
+
+        /// WCU (write capacity units) for the table. Acceptable only on Provisioned mode.
+        #[structopt(long)]
+        wcu: Option<i64>,
+
+        /// RCU (read capacity units) for the table. Acceptable only on Provisioned mode.
+        #[structopt(long)]
+        rcu: Option<i64>,
+
+        // TODO: support following parameters
+        // - sse_enabled: bool, (default false) ... UpdateTable API
+        // - stream_enabled: bool, (default false) ... UpdateTable API
+        // - ttl_enabled: bool, UpdateTimeToLive API
+        // - pitr_enabled: bool, UpdateContinuousBackups API (PITR)
+    },
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,10 +70,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 if all_tables { control::describe_all_tables(context).await }
                 else { control::describe_table(context).await }
             },
-            // cmd::AdminSub::Apply  { } => cfn::apply(context).await?,
             cmd::AdminSub::Create { target_type } => match target_type {
                 cmd::CreateSub::Table { new_table_name, keys } => control::create_table(context, new_table_name, keys).await,
                 cmd::CreateSub::Index { index_name, keys } => control::create_index(context, index_name, keys).await,
+            },
+            cmd::AdminSub::Update { target_type } => match target_type {
+                cmd::UpdateSub::Table { table_name_to_update, mode, wcu, rcu } => control::update_table(context, table_name_to_update, mode, wcu, rcu).await,
             },
             cmd::AdminSub::Delete { target_type } => match target_type {
                 cmd::DeleteSub::Table { table_name_to_delete, yes } => control::delete_table(context, table_name_to_delete, yes).await,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adding `dy admin update table` command to update existing table. For now it supports only following operations:

* changing mode (Provisioned/OnDemand)
* changing WCU/RCU of the base table

Example 1, switching from OnDemand mode to Provisioned mode with WCU/RCU specified. If you omit WCU/RCU, default value (5) would be used.
```
$ dy admin update table my_ondemand_table --mode provisioned --wcu 10 --rcu 25
```

Example 2, change only WCU of the Provisioned table.

```
$ dy admin update table my_provisioned_table --wcu 20
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
