### PR TITLE
Bump version to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dynein"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 name = "dynein"
 description = "DynamoDB Command Line Interface"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Takuya Hashimoto <thash@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:* release #1 and #2

*Description of changes:*

Release version 0.1.1. Change log:

* [Separate dynein configuration from table schema cache by thash · Pull Request #1 · awslabs/dynein](https://github.com/awslabs/dynein/pull/1)
* [Implement 'admin update table' command to call UpdateTable API for existing tables. Only mode and CU for now. by thash · Pull Request #2 · awslabs/dynein](https://github.com/awslabs/dynein/pull/2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
