### PR TITLE
run clippy on src/transfer.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+on: [push]
+
+name: CI
+
+jobs:
+  build_and_test:
+    name: Rust project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt, clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -237,7 +237,7 @@ async fn suggest_attributes(cx: &app::Context, ts: &app::TableSchema) -> Vec<Sug
                     false /* keys_only */, Some(1) /* limit */, None /* esk */
                 ).await.items.expect("items should be 'Some' even if there's no item in the table.");
 
-    if !items.is_empty() { app::bye(0, "No item to export in this table. Quit the operation."); }
+    if items.is_empty() { app::bye(0, "No item to export in this table. Quit the operation."); }
 
     // Filter out primary keys. i.e. select attributes that aren't required by the table's keyschema.
     let primary_keys = vec![Some(ts.pk.name.to_owned()), ts.sk.to_owned().map(|x| x.name)];


### PR DESCRIPTION
`cargo clippy` can reveal a ton of warnings for things that can be
improved slightly and can be really beneficial while developing. Since
there were so many warnings, I felt it was best just to fix one file to
show how simple it is, and as to not cause any conflicts with on going
work.

The main warnings were (in this file):
- `.as_ref().map(|x| x.as_str())` -> `.as_deref()`
- `.push_str("\n")` -> `.push('\n')`
- `.len() {>,==,!=} 0` -> `{!}.is_empty()`
- unneeded return statements
- needlessly taken references

Very cool project, I am excited to use it.

<details>

```
warning: called `.as_ref().map(|x| x.as_str())` on an Option value. This can be done more directly by calling `format.as_deref()` instead
  --> src/transfer.rs:59:36
   |
59 |     let format_str: Option<&str> = format.as_ref().map(|x| x.as_str() );
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using as_deref instead: `format.as_deref()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_as_ref_deref

warning: calling `push_str()` using a single-character string literal
   --> src/transfer.rs:117:21
    |
117 |                     s.push_str("\n");
    |                     ^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `s.push('\n')`
    |
    = note: `#[warn(clippy::single_char_add_str)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_add_str

warning: called `.as_ref().map(|x| x.as_str())` on an Option value. This can be done more directly by calling `format.as_deref()` instead
   --> src/transfer.rs:157:36
    |
157 |     let format_str: Option<&str> = format.as_ref().map(|x| x.as_str() );
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using as_deref instead: `format.as_deref()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_as_ref_deref

warning: single-character string constant used as pattern
   --> src/transfer.rs:184:55
    |
184 |             let lines: Vec<&str> = input_string.split("\n").collect::<Vec<&str>>() // split by "\n" and get lines
    |                                                       ^^^^ help: try using a `char` instead: `'\n'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: length comparison to zero
   --> src/transfer.rs:185:68
    |
185 | ...                   .iter().filter(|&x| x.len() > 0).cloned().collect::<Vec<&str>>(); // remove blank line (e.g. last line)
    |                                           ^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!x.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: single-character string constant used as pattern
   --> src/transfer.rs:186:53
    |
186 |             let headers: Vec<&str> = lines[0].split(",").collect::<Vec<&str>>();
    |                                                     ^^^ help: try using a `char` instead: `','`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: the loop variable `i` is used to index `lines`
   --> src/transfer.rs:189:22
    |
189 |             for i in 1..lines.len() {
    |                      ^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::needless_range_loop)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
help: consider using an iterator
    |
189 |             for (i, <item>) in lines.iter().enumerate().skip(1) {
    |                 ^^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: single-character string constant used as pattern
   --> src/transfer.rs:190:55
    |
190 |                 let cells: Vec<&str> = lines[i].split(",").collect::<Vec<&str>>();
    |                                                       ^^^ help: try using a `char` instead: `','`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: length comparison to zero
   --> src/transfer.rs:199:16
    |
199 |             if matrix.len() > 0 { write_csv_matrix(&cx, matrix.clone(), &headers).await?; }
    |                ^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!matrix.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: length comparison to zero
   --> src/transfer.rs:240:8
    |
240 |     if items.len() == 0 { app::bye(0, "No item to export in this table. Quit the operation."); }
    |        ^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `items.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: unneeded `return` statement
   --> src/transfer.rs:262:5
    |
262 | /     return attributes.clone().map(|ats|
263 | |         filter_attributes_to_append(&ts, ats)
264 | |     )
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
help: remove `return`
    |
262 |     attributes.clone().map(|ats|
263 |         filter_attributes_to_append(&ts, ats)
264 |     )
    |

warning: unneeded `return` statement
   --> src/transfer.rs:280:5
    |
280 |     return attributes_to_append;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `attributes_to_append`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: needlessly taken reference of both operands
   --> src/transfer.rs:274:12
    |
274 |         if &attr == &ts.pk.name || (ts.sk.is_some() && &attr == &ts.clone().sk.unwrap().name) {
    |            ^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#op_ref
help: use the values directly
    |
274 |         if attr == ts.pk.name || (ts.sk.is_some() && &attr == &ts.clone().sk.unwrap().name) {
    |            ^^^^    ^^^^^^^^^^

warning: needlessly taken reference of both operands
   --> src/transfer.rs:274:56
    |
274 |         if &attr == &ts.pk.name || (ts.sk.is_some() && &attr == &ts.clone().sk.unwrap().name) {
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#op_ref
help: use the values directly
    |
274 |         if &attr == &ts.pk.name || (ts.sk.is_some() && attr == ts.clone().sk.unwrap().name) {
    |                                                        ^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unneeded `return` statement
   --> src/transfer.rs:297:5
    |
297 |     return s;
    |     ^^^^^^^^^ help: remove `return`: `s`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
   --> src/transfer.rs:346:5
    |
346 |     return header_str;
    |     ^^^^^^^^^^^^^^^^^^ help: remove `return`: `header_str`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: calling `push_str()` using a single-character string literal
   --> src/transfer.rs:345:5
    |
345 |     header_str.push_str("\n");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `header_str.push('\n')`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_add_str

warning: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
   --> src/transfer.rs:367:79
    |
367 | async fn write_csv_matrix(cx: &app::Context, matrix: Vec<Vec<&str>>, headers: &Vec<&str>)
    |                                                                               ^^^^^^^^^^ help: change this to: `&[&str]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: 179 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 9.45s
```

</details>
