### PR TITLE
desc command supports both `dy desc mytbl` and `dy desc -t mytbl`

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -75,6 +75,9 @@ pub enum Sub {
     /// Show detailed information of a table. [API: DescribeTable]
     #[structopt(aliases = &["show", "describe", "info"])]
     Desc {
+        /// Target table name. Optionally you may specify the target table by --table (-t) option.
+        target_table_to_desc: Option<String>,
+
         /// Show details of all tables in the region
         #[structopt(long)]
         all_tables: bool,
@@ -362,6 +365,9 @@ pub enum AdminSub {
     /// Show detailed information of a table. [API: DescribeTable]
     #[structopt(aliases = &["show", "describe", "info"])]
     Desc {
+        /// Target table name. Optionally you may specify the target table by --table (-t) option.
+        target_table_to_desc: Option<String>,
+
         /// Show details of all tables in the region
         #[structopt(long)]
         all_tables: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,10 +64,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 if all_regions { control::list_tables_all_regions(context).await }
                 else { control::list_tables(context).await }
             },
-            cmd::AdminSub::Desc { all_tables, output } => {
+            cmd::AdminSub::Desc { target_table_to_desc, all_tables, output } => {
                 context.output = output;
                 if all_tables { control::describe_all_tables(context).await }
-                else { control::describe_table(context).await }
+                else { control::describe_table(context, target_table_to_desc).await }
             },
             cmd::AdminSub::Create { target_type } => match target_type {
                 cmd::CreateSub::Table { new_table_name, keys } => control::create_table(context, new_table_name, keys).await,
@@ -105,10 +105,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             if all_regions { control::list_tables_all_regions(context).await }
             else { control::list_tables(context).await }
         },
-        cmd::Sub::Desc { all_tables, output } => {
+        cmd::Sub::Desc { target_table_to_desc, all_tables, output } => {
             context.output = output;
             if all_tables { control::describe_all_tables(context).await }
-            else { control::describe_table(context).await }
+            else { control::describe_table(context, target_table_to_desc).await }
         },
         cmd::Sub::Use { target_table_to_use }  => app::use_table(&context, target_table_to_use).await?,
         cmd::Sub::Config { grandchild } => match grandchild {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Previously `dy desc` command only supports `--table (-t)` option to specify the target table.

Before this change:
```
$ dy desc Employee
error: Found argument 'Employee' which wasn't expected, or isn't valid in this context

USAGE:
    dy desc [FLAGS] [OPTIONS]
```

After this change:
```
$ dy desc Employee
---
name: Employee
region: ap-northeast-1
status: ACTIVE
schema:
  pk: LoginAlias (S)
  sk: ~
mode: OnDemand
...
created_at: "2020-11-09T10:30:03+00:00"
```

Now you can use both ways (like `dy use`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
