### PR TITLE
New feature: interactive shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ name = "dynein"
 version = "0.1.2"
 dependencies = [
  "assert_cmd",
+ "atty",
  "chrono",
  "dialoguer",
  "dirs 3.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ name = "dy"
 path = "src/main.rs"
 
 [dependencies]
+atty            = "0.2"
 chrono          = "0.4"
 dialoguer       = "0.7.1"
 dirs            = "3.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,10 @@ mod data;
 mod shell;
 mod transfer;
 
+/* =================================================
+   helper functions
+   =================================================
+*/
 async fn dispatch(mut context: app::Context, subcommand: cmd::Sub) -> Result<(), Box<dyn Error>> {
     match subcommand {
         cmd::Sub::Admin { grandchild } => match grandchild {
@@ -243,8 +247,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     debug!("Initial command context: {:?}", &context);
 
     if let Some(child) = c.child {
+        // subcommand
         dispatch(context, child).await?
     } else if c.shell {
+        // shell mode
         use shell::BuiltinCommands;
         use shell::ShellInput::*;
         use std::io::stdin;
@@ -267,6 +273,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     } else {
+        // Neiter subcommand nor --shell specified
         use structopt::StructOpt;
         eprintln!("Invalid argument: please specify a subcommand or '--shell'");
         cmd::Dynein::clap().print_help()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,8 +273,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         eprintln!("{}", e)
                     }
                 }
-                ParseError(e) => {
-                    eprintln!("Invalid argument: {}", e);
+                ParseError(_) => {
+                    // do nothing because read_line already handles the error
                 }
             }
         }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,70 @@
+use crate::cmd;
+use atty;
+use log::debug;
+use std::error::Error;
+use std::io::{stdout, BufRead, Stdin, StdinLock, Write};
+
+pub enum ShellInput {
+    Builtin(BuiltinCommands),
+    Command(cmd::Sub),
+    Eof,
+    ParseError(Box<dyn Error>),
+}
+
+pub enum BuiltinCommands {
+    Exit,
+}
+
+pub struct ShellReader<'a> {
+    line: String,
+    input: StdinLock<'a>,
+}
+
+impl<'a> ShellReader<'a> {
+    pub fn new(input: &'a Stdin) -> Self {
+        Self {
+            line: String::new(),
+            input: input.lock(),
+        }
+    }
+
+    pub fn read_line(&mut self) -> Result<ShellInput, Box<dyn Error>> {
+        if atty::is(atty::Stream::Stdin) {
+            print!("> ");
+            stdout().flush().expect("failed to flush output");
+        }
+
+        match self.input.read_line(&mut self.line) {
+            Ok(0) => {
+                // // append newline after '> '
+                // println!("");
+                return Ok(ShellInput::Eof);
+            }
+            Ok(_) => (),
+            Err(e) => return Err(Box::new(e)),
+        }
+
+        let line = self.line.trim_end();
+
+        debug!("Line read: {:?}", line);
+
+        match line {
+            // build-in shell command(s)
+            "exit" => Ok(ShellInput::Builtin(BuiltinCommands::Exit)),
+            // dy commands
+            line => {
+                // TODO: better handling of whitespaces
+                let args = line.split(' ');
+                debug!("Args: {:?}", args);
+                let child = match cmd::parse_args(args) {
+                    Ok(child) => child,
+                    Err(e) => {
+                        eprintln!("Invalid argument: {}", e);
+                        return Ok(ShellInput::ParseError(e));
+                    }
+                };
+                Ok(ShellInput::Command(child))
+            }
+        }
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -60,8 +60,6 @@ impl<'a> ShellReader<'a> {
         self.line.clear();
         match self.input.read_line(&mut self.line) {
             Ok(0) => {
-                // // append newline after '> '
-                // println!("");
                 return Ok(ShellInput::Eof);
             }
             Ok(_) => (),

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -33,7 +33,7 @@ impl<'a> ShellReader<'a> {
             print!("> ");
             stdout().flush().expect("failed to flush output");
         }
-
+        self.line.clear();
         match self.input.read_line(&mut self.line) {
             Ok(0) => {
                 // // append newline after '> '

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,8 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use crate::cmd;
 use atty;
 use log::debug;
 use std::error::Error;
 use std::io::{stdout, BufRead, Stdin, StdinLock, Write};
+
+/* =================================================
+struct / enum / const
+================================================= */
 
 pub enum ShellInput {
     Builtin(BuiltinCommands),
@@ -19,6 +39,10 @@ pub struct ShellReader<'a> {
     line: String,
     input: StdinLock<'a>,
 }
+
+/* =================================================
+inherent methods
+================================================= */
 
 impl<'a> ShellReader<'a> {
     pub fn new(input: &'a Stdin) -> Self {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -304,7 +304,8 @@ fn test_shell_mode() -> Result<(), Box<dyn std::error::Error>> {
     let shell_session = c.args(&["--region", "local", "--shell"]);
     let mut tmpfile = Builder::new().tempfile()?.into_file();
     writeln!(tmpfile, "admin create table {} --keys pk", table_name)?;
-    writeln!(tmpfile, "desc {}", table_name)?;
+    writeln!(tmpfile, "use {}", table_name)?;
+    writeln!(tmpfile, "desc")?;
     tmpfile.seek(SeekFrom::Start(0))?;
     shell_session
         .stdin(tmpfile)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -292,3 +292,28 @@ fn test_batch_write() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(cleanup(vec![table_name])?)
 }
+
+#[test]
+fn test_shell_mode() -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::{Seek, SeekFrom};
+
+    let table_name = "table--test_shell_mode";
+
+    // $ dy admin create table <table_name> --keys pk
+    let mut c = setup()?;
+    let shell_session = c.args(&["--region", "local", "--shell"]);
+    let mut tmpfile = Builder::new().tempfile()?.into_file();
+    writeln!(tmpfile, "admin create table {} --keys pk", table_name)?;
+    writeln!(tmpfile, "desc {}", table_name)?;
+    tmpfile.seek(SeekFrom::Start(0))?;
+    shell_session
+        .stdin(tmpfile)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "name: {}\nregion: local",
+            &table_name
+        )));
+
+    Ok(cleanup(vec![table_name])?)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This patch adds a new shell flag namely `--shell` . When `--shell` is passed without subcommands, dynein starts an interactive shell session. In the shell session, you can input any dynein subcommands and built-in shell command (currently,  only `exit` is defined to exit the shell).

```
$ dy --shell
> list
  hoge
  fuga
  piyo
> use fuga
Now you're using the table 'fuga' (ap-northeast-1);
> describe
---
name: fuga
region: ap-northeast-1
status: ACTIVE
....
> exit
```

As a bonus, you can  'script' the subcommands.

```console
$ cat script.txt
use fuga
describe
$ dy --shell < script.txt
...
```

How do you like this?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
