### PR TITLE
Run the integration tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     services:
       dynamodb-local:
         image: amazon/dynamodb-local
-        ports: 8000:8000
+        ports: "8000:8000"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ jobs:
   build_and_test:
     name: Rust project
     runs-on: ubuntu-latest
+    services:
+      dynamodb-local:
+        image: amazon/dynamodb-local
+        ports: 8000:8000
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -24,3 +28,7 @@ jobs:
         with:
           command: build
           args: --release --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-on: [push]
+on:
+  push:
 
 name: CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,23 +15,29 @@ jobs:
           - 8000:8000
     steps:
       - uses: actions/checkout@v2
+        name: "Check out"
       - uses: actions-rs/toolchain@v1
+        name: "Setup toolchain"
         with:
           toolchain: 1.47.0
           components: rustfmt, clippy
       - uses: actions-rs/cargo@v1
+        name: "Check format"
         with:
           command: fmt
           args: --all -- --check
       - uses: actions-rs/cargo@v1
+        name: "Lint"
         with:
           command: clippy
           args: -- -D warnings
       - uses: actions-rs/cargo@v1
+        name: "Build"
         with:
           command: build
           args: --release --all-features
       - uses: actions-rs/cargo@v1
+        name: "Test"
         with:
           command: test
           args: --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 on:
   push:
+  pull_request:
 
 name: CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     services:
       dynamodb-local:
         image: amazon/dynamodb-local
-        ports: 8000/tcp
+        ports:
+          - 8000:8000
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     services:
       dynamodb-local:
         image: amazon/dynamodb-local
-        ports: "8000:8000"
+        ports: 8000/tcp
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Current CI only checks if the project is formatted and compiles. With this patch, the integration tests are also run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
