### PR TITLE
Add port option for `--region local`

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -39,6 +39,9 @@ pub struct Dynein {
     #[structopt(short, long, global = true)]
     pub region: Option<String>,
 
+    #[structopt(short, long, global = true, required_if("region","local"))]
+    pub port: Option<u32>,
+
     /// Target table of the operation. You can use --table option in both top-level and subcommand-level.
     /// You can store table schema locally by executing `$ dy use`, after that you need not to specify --table on every command.
     #[structopt(short, long, global = true)]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -39,8 +39,7 @@ pub struct Dynein {
     #[structopt(short, long, global = true)]
     pub region: Option<String>,
 
-    /// Specifies the port number when with using `--region local`.
-    /// This option has an effect only when `--region local` is used.
+    /// Specify the port number. This option has an effect only when `--region local` is used.
     #[structopt(short, long, global = true)]
     pub port: Option<u32>,
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -39,7 +39,9 @@ pub struct Dynein {
     #[structopt(short, long, global = true)]
     pub region: Option<String>,
 
-    #[structopt(short, long, global = true, required_if("region","local"))]
+    /// Specifies the port number when with using `--region local`.
+    /// This option has an effect only when `--region local` is used.
+    #[structopt(short, long, global = true)]
     pub port: Option<u32>,
 
     /// Target table of the operation. You can use --table option in both top-level and subcommand-level.

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,8 +246,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         region: None,
         config: Some(app::load_or_touch_config_file(true)?),
         cache: Some(app::load_or_touch_cache_file(true)?),
-        overwritten_region: app::region_from_str(c.region),
+        overwritten_region: app::region_from_str(c.region, c.port),
         overwritten_table_name: c.table,
+        overwritten_port: None,
         output: None,
     };
     debug!("Initial command context: {:?}", &context);

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         cache: Some(app::load_or_touch_cache_file(true)?),
         overwritten_region: app::region_from_str(c.region, c.port),
         overwritten_table_name: c.table,
-        overwritten_port: None,
+        overwritten_port: c.port,
         output: None,
     };
     debug!("Initial command context: {:?}", &context);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -131,7 +131,7 @@ fn test_create_table() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_create_table_with_region_local_and_port_number_options() -> Result<(), Box<dyn std::error::Error>> {
     let port = 8001;
-    let table_name = "table--test_create_table";
+    let table_name = "table--test_create_table_with_region_local_and_port_number_options";
 
     // $ dy admin create table <table_name> --keys pk
     let mut c = setup_with_port(port)?;
@@ -147,7 +147,7 @@ fn test_create_table_with_region_local_and_port_number_options() -> Result<(), B
         )));
 
     // $ dy admin desc <table_name>
-    let mut c = setup()?;
+    let mut c = setup_with_port(port)?;
     let desc_cmd = c.args(&["--region", "local", "--port", &format!("{}", port), "desc", table_name]);
     desc_cmd
         .assert()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -53,7 +53,7 @@ fn setup_with_port(port: i32) -> Result<Command, Box<dyn std::error::Error>> {
     // possible workwround would be checking if a process is running and skip `docker run` if needed.
     // To avoid this issue, I'd sleep for a while in buildspec.yml (CodeBuild configuration).
     let docker_run = docker.args(&["run",
-                                   "-p", &format!("{}:{}", port, port),
+                                   "-p", &format!("{}:8000", port),
                                    "-d", "amazon/dynamodb-local" /*, "-jar", "DynamoDBLocal.jar", "-inMemory", "-port", &format!("{}", port) */]);
     let output = docker_run
         .output()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28,8 +28,11 @@ use tempfile::Builder;
 /// FYI: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
 ///      https://hub.docker.com/r/amazon/dynamodb-local
 fn setup() -> Result</* std::process::Command */ Command, Box<dyn std::error::Error>> {
+    setup_with_port(8000)
+}
+
+fn setup_with_port(port: i32) -> Result<Command, Box<dyn std::error::Error>> {
     // NOTE: setup() spins up DynamoDB Local in 8000 port as "local" region assumes it. Better to make it configurable.
-    let port = 8000;
     let mut docker = Command::new("docker");
 
     let check_cmd = docker.args(&[
@@ -66,6 +69,17 @@ fn cleanup(tables: Vec<&str>) -> Result<(), Box<dyn std::error::Error>> {
         let mut dynein_cmd = setup()?;
         let cmd = dynein_cmd.args(&[
             "--region", "local", "admin", "delete", "table", "--yes", table,
+        ]);
+        cmd.assert().success();
+    }
+    Ok(())
+}
+
+fn cleanup_with_port(tables: Vec<&str>, port: i32) -> Result<(), Box<dyn std::error::Error>> {
+    for table in tables {
+        let mut dynein_cmd = setup()?;
+        let cmd = dynein_cmd.args(&[
+            "--region", "local", "--port", &format!("{}", port), "admin", "delete", "table", "--yes", table,
         ]);
         cmd.assert().success();
     }
@@ -112,6 +126,38 @@ fn test_create_table() -> Result<(), Box<dyn std::error::Error>> {
         )));
 
     Ok(cleanup(vec![table_name])?)
+}
+
+#[test]
+fn test_create_table_with_region_local_and_port_number_options() -> Result<(), Box<dyn std::error::Error>> {
+    let port = 8001;
+    let table_name = "table--test_create_table";
+
+    // $ dy admin create table <table_name> --keys pk
+    let mut c = setup_with_port(port)?;
+    let create_cmd = c.args(&[
+        "--region", "local", "--port", &format!("{}", port), "admin", "create", "table", table_name, "--keys", "pk",
+    ]);
+    create_cmd
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "name: {}\nregion: local",
+            &table_name
+        )));
+
+    // $ dy admin desc <table_name>
+    let mut c = setup()?;
+    let desc_cmd = c.args(&["--region", "local", "--port", &format!("{}", port), "desc", table_name]);
+    desc_cmd
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "name: {}\nregion: local",
+            &table_name
+        )));
+
+    Ok(cleanup_with_port(vec![table_name], port)?)
 }
 
 #[test]


### PR DESCRIPTION
*Issue #21 , if available:*

*Description of changes:*
It is sometimes used together with localstack, and is often started with a different port number.
So, I want to use a different port number from 8000.
added the `--port` option to change the port number.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
