### PR TITLE
[fix] add --locked option to the cargo install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ dynein is written in Rust, so you can build and install dynein with Cargo. To bu
 ```
 $ git clone [[this_git_repository_url]]
 $ cd dynein
-$ cargo install --path .
+$ cargo install --locked --path .
 $ ./target/release/dy help
 ```
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Without `--locked` option, the `cargo install` command will fail when dependencies have already been yanked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
