### PR TITLE
Fix broken setup_with_port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "futures",
  "glob",
  "log",
+ "once_cell",
  "predicates 1.0.8",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tokio = { version = "0.2.16", features = ["full"] }
 [dev-dependencies]
 assert_cmd = "1.0.1" # contains helpers make executing the main binary on integration tests easier.
 predicates = "1.0.5" # to introduce advanced assertions
+once_cell = "1.8.0" # to setup docker container syncrhonously
 
 [build-dependencies]
 # Unless the "version_check" build dependency, proc-macro-error-attr v1.0.4 build would fail.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -66,7 +66,9 @@ fn check_dynamodb_local_running(port: u16) -> bool {
 }
 
 async fn setup_with_port(port: i32) -> Result<Command, Box<dyn std::error::Error>> {
-    // Check the current process at first to allow multiple threads to run tests concurrently
+    // Check the current process at first to allow multiple threads to run tests concurrently.
+    // This is for performance optimization on Windows and Mac OS.
+    // See https://github.com/awslabs/dynein/pull/28#issuecomment-972880324 for detail.
     if check_dynamodb_local_running(port as u16) {
         return Ok(Command::cargo_bin("dy")?);
     };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -42,7 +42,7 @@ async fn setup() -> Result</* std::process::Command */ Command, Box<dyn std::err
 static SETUP_MUTEX: Lazy<Mutex<i32>> = Lazy::new(|| Mutex::new(0));
 
 /// Check existence of docker process for dynamodb-local
-async fn check_dynamodb_local_running(port: u16) -> bool {
+fn check_dynamodb_local_running(port: u16) -> bool {
     let mut docker_for_check = Command::new("docker");
 
     let check_cmd = docker_for_check.args(&[
@@ -67,7 +67,7 @@ async fn check_dynamodb_local_running(port: u16) -> bool {
 
 async fn setup_with_port(port: i32) -> Result<Command, Box<dyn std::error::Error>> {
     // Check the current process at first to allow multiple threads to run tests concurrently
-    if check_dynamodb_local_running(port as u16).await {
+    if check_dynamodb_local_running(port as u16) {
         return Ok(Command::cargo_bin("dy")?);
     };
 
@@ -75,7 +75,7 @@ async fn setup_with_port(port: i32) -> Result<Command, Box<dyn std::error::Error
     let _lock = SETUP_MUTEX.lock();
 
     // Recheck whether another thread already started the dynamodb-local
-    if check_dynamodb_local_running(port as u16).await {
+    if check_dynamodb_local_running(port as u16) {
         return Ok(Command::cargo_bin("dy")?);
     }
 


### PR DESCRIPTION
*Description of changes:*
Previous `setup_with_port` actually fail to launch dynamodb-local.
This PR fixes broken `setup_with_port`. 

The main fix points are:

* `docker ps` was not able to filter intended container when old version docker is used. See [this PR](https://github.com/moby/moby/pull/40442).
* Variable `docker` was reused resulted in failure of `docker run`.
* We had to execute `cargo test` twice to pass tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
