### PR TITLE
[clean] clean up code to be compatible with 2018 edition

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -90,7 +90,7 @@ pub enum KeyType {
 
 /// implement Display for KeyType to simply print a single letter "S", "N", or "B".
 impl Display for KeyType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",
@@ -115,7 +115,7 @@ impl std::error::Error for ParseKeyTypeError {
 }
 
 impl Display for ParseKeyTypeError {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(f, "{}", self.message)
     }
 }
@@ -298,7 +298,7 @@ pub enum DyneinConfigError {
 }
 
 impl fmt::Display for DyneinConfigError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DyneinConfigError::IO(ref e) => e.fmt(f),
             DyneinConfigError::YAML(ref e) => e.fmt(f),

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -34,7 +34,7 @@ pub enum DyneinBatchError {
     BatchWriteError(RusotoError<BatchWriteItemError>),
 }
 impl fmt::Display for DyneinBatchError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DyneinBatchError::LoadData(ref e) => e.fmt(f),
             DyneinBatchError::PraseJSON(ref e) => e.fmt(f),

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -31,9 +31,6 @@ use tempfile::Builder;
 
 use serde_json::Value as JsonValue;
 
-extern crate reqwest;
-extern crate tempfile;
-
 use super::app;
 use super::batch;
 use super::control;

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -49,7 +49,7 @@ pub enum DyneinBootstrapError {
     BatchError(RusotoError<BatchWriteItemError>),
 }
 impl fmt::Display for DyneinBootstrapError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DyneinBootstrapError::LoadData(ref e) => e.fmt(f),
             DyneinBootstrapError::PraseJSON(ref e) => e.fmt(f),
@@ -371,7 +371,7 @@ async fn download_and_extract_zip(target: &str) -> Result<tempfile::TempDir, Dyn
     debug!("Opened the zip archive File just written: {:?}", zarchive);
 
     for i in 0..zarchive.len() {
-        let mut f: zip::read::ZipFile = zarchive.by_index(i)?;
+        let mut f: zip::read::ZipFile<'_> = zarchive.by_index(i)?;
         debug!("target ZipFile name: {}", f.name());
         let unzipped_fpath = tmpdir.path().join(f.name());
         debug!(

--- a/src/control.rs
+++ b/src/control.rs
@@ -27,7 +27,6 @@ use std::{
     time,
 };
 
-extern crate dialoguer;
 use dialoguer::{theme::ColorfulTheme, Confirm, Select};
 use tabwriter::TabWriter;
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -23,8 +23,6 @@ use std::{
     vec::Vec,
 };
 
-extern crate regex;
-
 use log::{debug, error};
 use regex::Regex;
 use rusoto_dynamodb::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,17 +14,8 @@
  * limitations under the License.
  */
 
-use std::error::Error;
-
-extern crate chrono;
-extern crate env_logger;
-extern crate log;
-extern crate rusoto_core;
-extern crate rusoto_dynamodb;
-extern crate serde_json;
-extern crate serde_yaml;
-
 use log::debug;
+use std::error::Error;
 
 mod app;
 mod batch;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -220,7 +220,7 @@ pub async fn import(
         }
         Some("jsonl") => {
             // JSON Lines can be deserialized with into_iter() as below.
-            let array_of_json_obj: StreamDeserializer<'_, StrRead, JsonValue> =
+            let array_of_json_obj: StreamDeserializer<'_, StrRead<'_>, JsonValue> =
                 Deserializer::from_str(&input_string).into_iter::<JsonValue>();
             // list_of_jsons contains deserialize results. Filter them and get only valid items.
             let array_of_valid_json_obj: Vec<JsonValue> =


### PR DESCRIPTION
*Issue #29 , if available:* As the extern prelude is introduced in 2018 edition, `extern crate` is unidiomatic.

*Description of changes:* Removes `extern crate`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
