### PR TITLE
Add descending option

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -191,6 +191,11 @@ pub enum Sub {
         #[structopt(long)]
         keys_only: bool,
 
+        /// Results of query are always sorted by the sort key value. By default, the sort order is ascending.
+        /// Specify --descending to traverse descending order.
+        #[structopt(short, long)]
+        descending: bool,
+
         /// Switch output format.
         #[structopt(short, long, possible_values = &["table", "json", "raw"])]
         output: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use crate::data::QueryParams;
 use log::debug;
 use std::error::Error;
 
@@ -106,17 +107,21 @@ async fn dispatch(context: &mut app::Context, subcommand: cmd::Sub) -> Result<()
             attributes,
             consistent_read,
             keys_only,
+            descending,
             output,
         } => {
             context.output = output;
             data::query(
                 context.clone(),
-                pval,
-                sort_key_expression,
-                index,
-                consistent_read,
-                &attributes,
-                keys_only,
+                QueryParams {
+                    pval,
+                    sort_key_expression,
+                    index,
+                    consistent_read,
+                    descending,
+                    attributes,
+                    keys_only,
+                },
             )
             .await
         }


### PR DESCRIPTION
*Issue #, if available:*

This PR implement #20 request's ScanIndexForward support.

*Description of changes:*

Add `--descending` options to support ScanIndexForward attribute.
API documentation available [here](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
