### PR TITLE
Add a GitHub action to build dynein binaries on the new release created

### DIFF
--- a/.github/workflows/build_binaries_on_new_releases.yml
+++ b/.github/workflows/build_binaries_on_new_releases.yml
@@ -1,0 +1,76 @@
+name: Build binaries on new releases
+on:
+  # the workflow starts on new release publised https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#release
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build_dynein_binary:
+    runs-on: ${{ matrix.os }}
+    env:
+      RUST_BACKTRACE: 1 # Dump backtrace on panic
+    strategy:
+      fail-fast: false
+      matrix:
+        # NOTE: Apple M1 (ARM) environment in GitHub action is not yet supported: https://github.com/actions/virtual-environments/issues/2187
+        name: [linux, linux-arm, macos, windows]
+        include:
+        - name: linux
+          os: ubuntu-latest
+          target: x86_64-unknown-linux-musl
+        - name: linux-arm
+          os: ubuntu-latest
+          target: arm-unknown-linux-gnueabihf
+        - name: macos
+          os: macos-latest
+          target: x86_64-apple-darwin
+        - name: windows
+          os: windows-2019
+          target: x86_64-pc-windows-msvc
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        default: true
+        override: true # override toolchain from "rust-toolchain" file
+        target: ${{ matrix.target }}
+
+    # cargo build on each OS generates a binary named "dy" under ./target/release/ directory.
+    - run: cargo build --verbose --release
+
+    - name: Strip the binary to reduce its size (linux and macos)
+      if: matrix.name == 'linux' || matrix.name == 'macos'
+      run: strip ./target/release/dy
+    - name: Archive the binary for publishing on release assets
+      shell: bash
+      run: |
+        if [ "${{ matrix.os }}" = "windows-2019" ]; then
+          7z a -tzip dynein-${{ matrix.name }}.zip ./target/release/dy.exe
+        else
+          tar -C ./target/release/ -cvf dynein-${{ matrix.name }}.tar.gz dy
+        fi
+    - name: Generate SHA256 checksum
+      if: matrix.name != 'windows'
+      run: |
+        if [ "${{ matrix.os }}" = "macos-latest" ]; then
+          shasum -a 256 dynein-${{ matrix.name }}.tar.gz > dynein-${{ matrix.name }}.tar.gz.sha256
+        elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          sha256sum dynein-${{ matrix.name }}.tar.gz > dynein-${{ matrix.name }}.tar.gz.sha256
+        else
+          echo "matrix.os: ${{ matrix.os }} is not handled."
+        fi
+
+    - name: Display current files (linux, linux-arn, and macos)
+      if: matrix.name == 'linux' || matrix.name == 'linux-arn' || matrix.name == 'macos'
+      run: ls -lrt && ls -lrt ./target/ && ls -lrt ./target/release/
+
+    - name: Create a release with the binary file
+      uses: softprops/action-gh-release@v1
+      # this uploading step to the release asseets works only when the target ref has tagged starts with "v" https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+      if: startsWith( github.ref, 'refs/tags/v' )
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: dynein-*

--- a/README.md
+++ b/README.md
@@ -65,29 +65,32 @@ dynein - DynamoDB CLI
 
 ## Method 1. Download binaries
 
-macOS
+You can download binaries of a specific version from [the releases page](https://github.com/awslabs/dynein/releases). For example, below instructions are example comamnds to download the latest version in each platform.
+
+### macOS
 
 ```
-$ curl -O -L https://github.com/awslabs/dynein/releases/latest/download/dynein-darwin.tar.gz
-$ tar xzvf dynein-darwin.tar.gz
+$ curl -O -L https://github.com/awslabs/dynein/releases/latest/download/dynein-macos.tar.gz
+$ tar xzvf dynein-macos.tar.gz
 $ mv dy /usr/local/bin/
-$ chmod +x /usr/local/bin/dy
 $ dy --help
 ```
 
-Linux x86 (64-bit)
+Currently, the above binary is automatically built on intel mac as [the GitHub Action doesn't support Apple M1 (ARM) environment yet](https://github.com/actions/virtual-environments/issues/2187).
+
+### Linux (x86-64)
 
 ```
 $ curl -O -L https://github.com/awslabs/dynein/releases/latest/download/dynein-linux.tar.gz
 $ tar xzvf dynein-linux.tar.gz
 $ sudo mv dy /usr/local/bin/
-$ chmod +x /usr/local/bin/dy
 $ dy --help
 ```
 
-## Method 2. Homebrew (MacOS)
 
-(currently not available)
+## Method 2. Homebrew (macOS)
+
+Currently not available. Please use the Method 1 above.
 
 ## Method 3. Building from source
 
@@ -97,7 +100,7 @@ dynein is written in Rust, so you can build and install dynein with Cargo. To bu
 $ git clone [[this_git_repository_url]]
 $ cd dynein
 $ cargo install --locked --path .
-$ ./target/release/dy help
+$ ./target/release/dy --help
 ```
 
 You can move the binary file named "dy" to anywhere under your `$PATH`.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This pull request adds a new GitHub Action workflow definition that builds dynein binaries automatically when a new release is published by maintainers.
Also, tiny modifications are made on README so that it matches the new build procedure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
