### PR TITLE
[fix] "dy ls" doesn't work when cache exists and table name is not specified

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -266,6 +266,14 @@ impl Context {
     }
 
     pub fn cached_using_table_schema(&self) -> Option<TableSchema> {
+        // return None if table name is not specified in both config and option.
+        if self.overwritten_table_name == None {
+            match self.config.to_owned() {
+                Some(c) => c.using_table?,
+                None => return None,
+            };
+        }
+
         let cached_tables: HashMap<String, TableSchema> =
             match self.cache.to_owned().and_then(|c| c.tables) {
                 Some(cts) => cts,


### PR DESCRIPTION
*Issue #18, if available:*
`dy list` doesn't work under the condition where `~/.dynein/cache.yml` contains at least one cached table and table name is not specified in both `~/.dynein/config.yml` and `--table` option.

*Description of changes:*
`cached_using_table_schema()` (only used in `list_tables()`) returns `None` when table name is not specified in both `~/.dynein/config.yml` and `--table` option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
