### PR TITLE
refactor: reduce clone usage

### DIFF
--- a/src/ddb/key.rs
+++ b/src/ddb/key.rs
@@ -99,8 +99,8 @@ impl FromStr for KeyType {
 /// Used when you want to know "what is the Partition Key name and its data type of this table".
 pub fn typed_key(pk_or_sk: &str, desc: &TableDescription) -> Option<Key> {
     // extracting key schema of "base table" here
-    let ks = desc.clone().key_schema.unwrap();
-    typed_key_for_schema(pk_or_sk, &ks, &desc.clone().attribute_definitions.unwrap())
+    let ks = desc.key_schema.as_ref().unwrap();
+    typed_key_for_schema(pk_or_sk, ks, desc.attribute_definitions.as_ref().unwrap())
 }
 
 /// Receives key data type (HASH or RANGE), KeySchemaElement(s), and AttributeDefinition(s),
@@ -113,7 +113,7 @@ pub fn typed_key_for_schema(
     // Fetch Partition Key ("HASH") or Sort Key ("RANGE") from given Key Schema. pk should always exists, but sk may not.
     let target_key = ks.iter().find(|x| x.key_type == pk_or_sk.into());
     target_key.map(|key| Key {
-        name: key.clone().attribute_name,
+        name: key.attribute_name.to_owned(),
         // kind should be one of S/N/B, Which can be retrieved from AttributeDefinition's attribute_type.
         kind: KeyType::from_str(
             attrs


### PR DESCRIPTION
*Issue #, if available:*
This PR is related to #6.

*Description of changes:*
This PR reduces the use of `clone`.
There are primary and accompanying goals such as:

* Reduce `clone` to improve performance.
* Currently, there is no good way to update the context cache without quitting the program. It causes an incoherent cache on shell mode. Mutable reference is a way to solve this problem. As of this pull request, we have not introduced a cache update.
* Give future ability into context to hold another cache like "item cache," which is required to implement completions.

I welcome the discussion to achieve the above goals.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
