### PR TITLE
remove unused region field in Context

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -190,7 +190,6 @@ pub struct Cache {
 
 #[derive(Debug, Clone)]
 pub struct Context {
-    pub region: Option<Region>,
     pub config: Option<Config>,
     pub cache: Option<Cache>,
     pub overwritten_region: Option<Region>, // --region option
@@ -730,7 +729,6 @@ mod tests {
     #[test]
     fn test_context_functions() -> Result<(), Box<dyn Error>> {
         let cx1 = Context {
-            region: None,
             config: None,
             cache: None,
             overwritten_region: None,
@@ -742,7 +740,6 @@ mod tests {
         // cx1.effective_table_name(); ... exit(1)
 
         let cx2 = Context {
-            region: None,
             config: Some(Config {
                 using_region: Some(String::from("ap-northeast-1")),
                 using_table: Some(String::from("cfgtbl")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // when --region <region-name e.g. ap-northeast-1>, use the region. when --region local, use DynamoDB local.
     // --region/--table option can be passed as a top-level or subcommand-level (i.e. global).
     let mut context = app::Context {
-        region: None,
         config: Some(app::load_or_touch_config_file(true)?),
         cache: Some(app::load_or_touch_cache_file(true)?),
         overwritten_region: app::region_from_str(c.region, c.port),


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
As `region` field in `Context` is not used anywhere, remove it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
