### PR TITLE
Add a flag DYNEIN_TEST_NO_DOCKER_SETUP to prevent launching docker container on testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   build_and_test:
     name: Rust project
     runs-on: ubuntu-latest
+    env:
+      DYNEIN_TEST_NO_DOCKER_SETUP: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
*Issue #56, if available:*

*Description of changes:*
If you specify `DYNEIN_TEST_NO_DOCKER_SETUP=true` on environment variable, `cargo test` does not start docker container on testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
