### PR TITLE
Adds zip flag to tar command for artifact build, closing #95

### DIFF
--- a/.github/workflows/build_binaries_on_new_releases.yml
+++ b/.github/workflows/build_binaries_on_new_releases.yml
@@ -49,7 +49,7 @@ jobs:
         if [ "${{ matrix.os }}" = "windows-2019" ]; then
           7z a -tzip dynein-${{ matrix.name }}.zip ./target/release/dy.exe
         else
-          tar -C ./target/release/ -cvf dynein-${{ matrix.name }}.tar.gz dy
+          tar -C ./target/release/ -cvzf dynein-${{ matrix.name }}.tar.gz dy
         fi
     - name: Generate SHA256 checksum
       if: matrix.name != 'windows'


### PR DESCRIPTION
*Issue 95:*

*Description of changes:*
Added the 'z' flag to tar command to gzip the archive, matching the `.tar.gz` naming of the artifact file.
Alternatively, you could drop the `gz` and just upload the file as tar.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
