### PR TITLE
Allow users to change location of config files with env var DYNEIN_CONFIG_DIR

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -673,7 +673,7 @@ fn retrieve_dynein_file_path(dft: DyneinFileType) -> Result<String, DyneinConfig
 }
 
 fn retrieve_or_create_dynein_dir() -> Result<String, DyneinConfigError> {
-    let path = env::var(CONFIG_PATH_ENV_VAR_NAME).unwrap_or(
+    let full_path = env::var(CONFIG_PATH_ENV_VAR_NAME).unwrap_or(
         dirs::home_dir()
             .ok_or(DyneinConfigError::HomeDir)?
             .to_str()
@@ -681,10 +681,15 @@ fn retrieve_or_create_dynein_dir() -> Result<String, DyneinConfigError> {
             .to_string(),
     );
 
-    let dir = format!("{}/{}", path, CONFIG_DIR);
+    let dir = path::Path::new(&full_path)
+        .join(CONFIG_DIR)
+        .to_str()
+        .ok_or(DyneinConfigError::HomeDir)?
+        .to_string();
+
     if !path::Path::new(&dir).exists() {
         debug!("Creating dynein config directory: {}", dir);
-        fs::create_dir(&dir)?;
+        fs::create_dir_all(&dir)?;
     };
 
     Ok(dir)

--- a/src/app.rs
+++ b/src/app.rs
@@ -681,18 +681,14 @@ fn retrieve_or_create_dynein_dir() -> Result<String, DyneinConfigError> {
             .to_string(),
     );
 
-    let dir = path::Path::new(&full_path)
-        .join(CONFIG_DIR)
-        .to_str()
-        .ok_or(DyneinConfigError::HomeDir)?
-        .to_string();
+    let dir = path::Path::new(&full_path).join(CONFIG_DIR);
 
-    if !path::Path::new(&dir).exists() {
-        debug!("Creating dynein config directory: {}", dir);
+    if !dir.exists() {
+        debug!("Creating dynein config directory: {}", dir.display());
         fs::create_dir_all(&dir)?;
     };
 
-    Ok(dir)
+    Ok(dir.to_str().ok_or(DyneinConfigError::HomeDir)?.to_string())
 }
 
 /// This function updates `using_region` and `using_table` in config.yml,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -155,6 +155,37 @@ async fn test_help() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+async fn cleanup_config(dummy_dir: &str) -> io::Result<()> {
+    use std::fs::remove_dir_all;
+
+    remove_dir_all(dummy_dir)
+}
+
+#[tokio::test]
+async fn test_custom_config_location() -> Result<(), Box<dyn std::error::Error>> {
+    use std::path::Path;
+
+    let dummy_dir = "./tests/dummy_dir";
+    let config_dir = dummy_dir.to_string() + "/.dynein";
+
+    // cleanup config folder in case it was already there
+    cleanup_config(dummy_dir).await.ok();
+
+    // dy config clear
+    Command::cargo_bin("dy")?
+        .args(&["config", "clear"])
+        .env("DYNEIN_CONFIG_DIR", dummy_dir)
+        .output()?;
+
+    // check config folder created at our desired location
+    assert!(Path::new(&config_dir).exists());
+
+    // cleanup config folder
+    cleanup_config(dummy_dir).await.ok();
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_create_table() -> Result<(), Box<dyn std::error::Error>> {
     let table_name = "table--test_create_table";


### PR DESCRIPTION
Program now checks environment variable DYNEIN_CONFIG_DIR and if set, uses that as the location to store the configuration files

*Issue #, if available:* 106

*Description of changes:* Program now checks environment variable DYNEIN_CONFIG_DIR and if set, uses that as the location to store the configuration files. The environment variable's name is in a global variable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
