### PR TITLE
refactor: return error when download is failed

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -355,7 +355,11 @@ async fn download_and_extract_zip(target: &str) -> Result<tempfile::TempDir, Dyn
     debug!("temporary download & unzip directory: {:?}", &tmpdir);
 
     println!("Temporarily downloading sample data from {}", target);
-    let res_bytes = reqwest::get(target).await?.bytes().await?;
+    let res_bytes = reqwest::get(target)
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
     let fpath: PathBuf = tmpdir.path().join("downloaded_sampledata.zip");
     debug!("Downloading the file at: {}", &fpath.display());
     let mut zfile: File = File::create(fpath.clone())?;


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

ZipError occur when downloading sample is failed that it is not helpful to investigate what is happened.

```
Temporarily downloading sample data from https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/samples/sampledata.zip
Error: ZipError(InvalidArchive("Could not find central directory end"))
```

We can use `error_for_status` to detect error from target URL such as 403 as follows.

```
Temporarily downloading sample data from https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/samples/sampledata.zip
Error: ReqwestError(reqwest::Error { kind: Status(403), url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("docs.aws.amazon.com")), port: None, path: "/amazondynamodb/latest/developerguide/samples/sampledata.zip", query: None, fragment: None } })
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
