### PR TITLE
chore: Introduce pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.8.0
+  hooks:
+  - id: pretty-format-yaml
+    args: [--autofix, --indent, '2']
+  - id: pretty-format-rust
+    entry: rustfmt --edition 2018
+    files: ^.*\.rs$
+- repo: local
+  hooks:
+  - id: rust-clippy
+    name: Rust clippy
+    description: Run cargo clippy on files included in the commit. clippy must be installed before-hand.
+    entry: cargo clippy -- -D warnings
+    pass_filenames: false
+    types: [file, rust]
+    language: system

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ dynein - DynamoDB CLI
         - [`dy import`](#dy-import)
     - [Using DynamoDB Local with `--region local` option](#using-dynamodb-local-with---region-local-option)
 - [Misc](#misc)
+    - [Development](#development)
     - [Asides](#asides)
     - [Troubleshooting](#troubleshooting)
     - [Ideas for future works](#ideas-for-future-works)
@@ -798,6 +799,23 @@ $ dy scan
 
 
 # Misc
+
+## Development
+For development, we use `rustfmt` and `clippy` to maintain the quality of our source code.
+Before starting, please ensure both components are installed;
+
+```shell
+rustup component add rustfmt clippy
+```
+
+Additionally, we use `pre-commit` hooks to execute automated linting and basic checks.
+Please set it up before creating a commit;
+
+```shell
+brew install pre-commit # (or appropriate for your platform: https://pre-commit.com/)
+pre-commit install
+```
+
 
 ## Asides
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We can easily forget to run `cargo fmt --all` and `cargo clippy -- -D warnings`. Although #117 enforces success of those commands upon pull requests, local running is useful for daily development.

This pull request adds configuration for [`pre-commit`](https://pre-commit.com/) to execute above commands on pre-commit hook.

FYI: [smithy](https://github.com/awslabs/smithy-rs) uses `pre-commit`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
