### PR TITLE
chore: Restore push event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
 
 name: CI
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Commit 5db95228a212 replaced `push` event with `pull_request` event, but the `push` event is still requried to run CI on top of the main branch after merging PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
