### PR TITLE
fix: specify user_agent when download sample.

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -41,6 +41,8 @@ use super::data;
 struct / enum / const
 ================================================= */
 
+const USER_AGENT: &str = concat!("dynein/", env!("CARGO_PKG_VERSION"));
+
 #[derive(Debug)]
 pub enum DyneinBootstrapError {
     LoadData(IOError),
@@ -356,7 +358,13 @@ async fn download_and_extract_zip(target: &str) -> Result<tempfile::TempDir, Dyn
     debug!("temporary download & unzip directory: {:?}", &tmpdir);
 
     println!("Temporarily downloading sample data from {}", target);
-    let res_bytes = reqwest::get(target)
+
+    let clinet = reqwest::ClientBuilder::new()
+        .user_agent(USER_AGENT)
+        .build()?;
+    let res_bytes = clinet
+        .get(target)
+        .send()
         .await?
         .error_for_status()?
         .bytes()


### PR DESCRIPTION
*Issue #, if available:*

Fix #103

*Description of changes:*

If user_agent is not specified, the server response 403 error as follows.

```
$ RUST_LOG=debug cargo run -- bootstrap
...
[2023-05-12T17:38:28Z DEBUG dy::bootstrap] temporary download & unzip directory: TempDir { path: "/var/folders/ys/zr1z7ql10kvcp8v3g2zbyp080000gs/T/.tmpvtdrOq" }
Temporarily downloading sample data from https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/samples/sampledata.zip
[2023-05-12T17:38:28Z DEBUG reqwest::connect] starting new connection: https://docs.aws.amazon.com/
Error: ReqwestError(reqwest::Error { kind: Status(403), url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("docs.aws.amazon.com")), port: None, path: "/amazondynamodb/latest/developerguide/samples/sampledata.zip", query: None, fragment: None } })
```

If user_agent is specified, the download is succeeded.

```
[2023-05-12T17:41:46Z DEBUG dy::bootstrap] temporary download & unzip directory: TempDir { path: "/var/folders/ys/zr1z7ql10kvcp8v3g2zbyp080000gs/T/.tmpypvWPL" }
Temporarily downloading sample data from https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/samples/sampledata.zip
[2023-05-12T17:41:46Z DEBUG reqwest::connect] starting new connection: https://docs.aws.amazon.com/
[2023-05-12T17:41:47Z DEBUG dy::bootstrap] Downloading the file at: /var/folders/ys/zr1z7ql10kvcp8v3g2zbyp080000gs/T/.tmpypvWPL/downloaded_sampledata.zip
[2023-05-12T17:41:47Z DEBUG dy::bootstrap] Finished writing content of the downloaded data into '/var/folders/ys/zr1z7ql10kvcp8v3g2zbyp080000gs/T/.tmpypvWPL/downloaded_sampledata.zip'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
