### PR TITLE
chore: exclude markdown files in cmd directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ repos:
   rev: v3.2.0
   hooks:
   - id: trailing-whitespace
+    exclude: ^tests/cmd/.*$
   - id: end-of-file-fixer
+    exclude: ^tests/cmd/.*$
   - id: check-yaml
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.8.0


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add `tests/cmd` directory into the exclude list for pre-commit hooks to prevent breaking tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
