### PR TITLE
implement correct parsing for UpdateItem API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -569,13 +569,17 @@ version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "atty",
+ "bytes",
  "chrono",
  "dialoguer",
  "dirs",
  "env_logger",
  "futures",
+ "itertools",
  "log",
  "once_cell",
+ "pest",
+ "pest_derive",
  "predicates 2.1.5",
  "regex",
  "reqwest",
@@ -1400,6 +1404,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "pest"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,7 +1635,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2280,6 +2328,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ tempfile         = "3.3.0"
 termcolor        = "1.1.2"
 zip              = "0.6.4"
 tokio = { version = "1.15.0", features = ["full"] }
+pest = "2.6.0"
+pest_derive = "2.6.0"
+bytes = "1.4.0"
+itertools = "0.10.5"
 
 [dev-dependencies]
 assert_cmd = "2.0.2" # contains helpers make executing the main binary on integration tests easier.

--- a/src/expression.pest
+++ b/src/expression.pest
@@ -1,0 +1,119 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+WHITESPACE = _{ SEPARATOR }
+
+// EOI always produces token.
+// I use eoi instead of EIO to suppress generating token.
+// See: https://github.com/pest-parser/pest/issues/304
+eoi = _{ !ANY }
+
+// You can find the grammar for actions of UpdateItem in the following link.
+// https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html
+set_action = { SOI ~ path ~ "=" ~ value ~ ("," ~ path ~ "=" ~ value)* ~ eoi }
+remove_action = { SOI ~ path ~ ("," ~ path)* ~ eoi }
+
+path = { attr_access ~ ("." ~ attr_access)* }
+attr_access = _{ attr_name ~ list_elem* }
+
+// Attribute name can be quoted by backticks.
+attr_name = _{ "`" ~ quoted_identifier ~ "`" | non_quoted_identifier }
+
+// You can write attribute name for a`b with a``b like MySQL.
+// https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+quoted_identifier = @{ ("``" | (!"`" ~ ANY))+ }
+
+// Dynein allows non ASCII path identifier without quoting.
+non_quoted_identifier = @{ (!special_character ~ XID_START) ~ (!special_character ~ XID_CONTINUE)* }
+
+// Backtick (`), double quote ("), single quote (') and back slash (\) have a special meaning in dynein.
+// Currently, DynamoDB does not use an asterisk (*), slash (/), percent sign (%) as a special character.
+// However, dynein treats them as special characters for understandability.
+special_character = _{
+  SEPARATOR | "\\" | "`" | "\"" | "'" | "=" | "<" | "<" | ">" | "[" | "]" | "+" | "-" | "*" | "/" | "%" | "."
+}
+
+// DynamoDB does not allow the plus sign for an index of a list.
+list_elem = _{ "[" ~ list_index_number ~ "]" }
+list_index_number = @{ (ASCII_NONZERO_DIGIT+ ~ ASCII_DIGIT*) | "0" }
+
+// DynamoDB allows parentheses to group expressions but does not allow redundancy.
+value = { "(" ~ plus_expression ~ ")" | "(" ~ minus_expression ~ ")" | plus_expression | minus_expression | operand }
+plus_expression = { operand ~ "+" ~ operand }
+minus_expression = { operand ~ "-" ~ operand }
+
+// Note: Unary operators, plus (+), minus (-) are not allowed in DynamoDB.
+//       But, they can be prepended before a number literal.
+operand = { function | literal | path  }
+function = { list_append_function | if_not_exists_function }
+list_append_function = { ^"list_append" ~ "(" ~ list_append_parameter ~ "," ~ list_append_parameter ~ ")" }
+list_append_parameter = { path | list_literal }
+if_not_exists_function = { ^"if_not_exists" ~ "(" ~ path ~ "," ~ value ~ ")" }
+
+// Literals
+literal = _{
+  boolean_literal | null_literal | b_literal | list_literal | map_literal  | string_literal | number_literal |
+  set_literal
+}
+
+// Boolean literals
+boolean_literal = _{ true_literal | false_literal }
+true_literal = @{ ^"true" }
+false_literal = @{ ^"false" }
+
+// Null literal
+null_literal = @{ ^"null" }
+
+// String literals
+string_literal = _{ double_quote_literal | single_quote_literal }
+double_quote_literal = @{ "\"" ~ ("\\0" | "\\r" | "\\n" | "\\t" | "\\\\" | "\\\"" | "\\'" | (!"\"" ~ ANY))* ~ "\"" }
+single_quote_literal = @{ "'" ~ (!"\'" ~ ANY)* ~ "'" }
+
+// Number literals
+number_literal = @{ exp_number_literal | decimal_floating_number_literal | integer_literal }
+integer_literal = _{ ("+" | "-")? ~ ASCII_DIGIT+ }
+decimal_floating_number_literal = _{
+  ("+" | "-")? ~ ((ASCII_DIGIT* ~ "." ~ ASCII_DIGIT+) | (ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT*))
+}
+exp_number_literal = _{ (decimal_floating_number_literal | integer_literal) + ~ ^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+ }
+
+// Binary literals
+// We introduce the same grammar and semantics that Rust uses without SUFFIX.
+// See: https://doc.rust-lang.org/reference/tokens.html#byte-and-byte-string-literals
+b_literal = _{ "b" ~ (binary_string_literal | binary_literal) }
+binary_literal = @{ "'" ~ (byte_escape | ascii_for_char)* ~ "'" }
+ascii_for_char = _{ !("'" | "\\" | "\n" | "\r" | "\t") ~ '\x00'..'\x7F' }
+byte_escape = _{ "\\x" ~ ASCII_HEX_DIGIT ~ ASCII_HEX_DIGIT | "\\n" | "\\r" | "\\t" | "\\\\" | "\\0" | "\\'" | "\\\"" }
+binary_string_literal = @{ "\"" ~ (byte_escape | string_continue | ascii_for_string)* ~ "\"" }
+string_continue = _{ "\\" ~ &"\n" }
+ascii_for_string = _{ !(isolated_cr | "\"" | "\\") ~ '\x00'..'\x7F' }
+isolated_cr = _{ "\r" ~ &"\n" }
+
+// List literal
+list_literal = { "[" ~ literal? ~ ("," ~ literal)* ~ "]" }
+
+// Map literal
+map_literal = { "{" ~ map_pair? ~ ("," ~ map_pair)* ~ "}" }
+map_pair = { map_key ~ ":" ~ map_value }
+map_key = { string_literal }
+map_value = { literal }
+
+// We allow PartiQL style string set literal and number set literal.
+set_literal = _{ "<<" ~ (string_set_literal | binary_set_literal | number_set_literal) ~ ">>" }
+string_set_literal = { string_set_element ~ ("," ~ string_set_element)* }
+string_set_element = _{ (double_quote_literal | single_quote_literal) }
+number_set_literal = { number_literal ~ ("," ~ number_literal)*  }
+binary_set_literal = { b_literal ~ ("," ~ b_literal)* }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,12 +18,17 @@ use crate::data::QueryParams;
 use log::debug;
 use std::error::Error;
 
+extern crate pest;
+#[macro_use]
+extern crate pest_derive;
+
 mod app;
 mod batch;
 mod bootstrap;
 mod cmd;
 mod control;
 mod data;
+mod parser;
 mod shell;
 mod transfer;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,1479 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::pest::Parser;
+use bytes::Bytes;
+use itertools::Itertools;
+use pest::iterators::Pair;
+use rusoto_dynamodb::AttributeValue;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Parser)]
+#[grammar = "expression.pest"]
+struct GeneratedParser;
+
+type SetAction = Vec<AtomicSet>;
+type RemoveAction = Vec<AtomicRemove>;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct AtomicSet {
+    path: Path,
+    value: Value,
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+struct AtomicRemove {
+    path: Path,
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+struct Path {
+    elements: Vec<PathElement>,
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+enum PathElement {
+    Attribute(String),
+    Index(String),
+}
+
+impl Path {
+    fn new() -> Path {
+        Path {
+            elements: Vec::new(),
+        }
+    }
+
+    fn add_attr(&mut self, attr: String) {
+        self.elements.push(PathElement::Attribute(attr));
+    }
+
+    fn add_index(&mut self, idx: String) {
+        self.elements.push(PathElement::Index(idx));
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum Value {
+    PlusExpression(Operand, Operand),
+    MinusExpression(Operand, Operand),
+    Operand(Operand),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum Operand {
+    Function(Function),
+    Literal(AttrVal),
+    Path(Path),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum Function {
+    ListAppendFunction(ListAppendParameter, ListAppendParameter),
+    IfNotExistsFunction(Path, Box<Value>),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum ListAppendParameter {
+    Path(Path),
+    ListLiteral(AttrVal),
+}
+
+/// The result of parsing expression
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExpressionResult {
+    exp: String,
+    names: HashMap<String, String>,
+    values: HashMap<String, AttributeValue>,
+}
+
+impl ExpressionResult {
+    pub fn get_expression(&self) -> String {
+        self.exp.clone()
+    }
+
+    pub fn get_names(&self) -> HashMap<String, String> {
+        self.names.clone()
+    }
+
+    pub fn get_values(&self) -> HashMap<String, AttributeValue> {
+        self.values.clone()
+    }
+}
+
+/// The error context of an unexpected end of a string
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct EscapeEOS {
+    pub handling_target: String,
+    pub escape_char: char,
+    pub escape_pos: usize,
+}
+
+impl Display for EscapeEOS {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Unexpected end of the string at handling escape char '{}' at {} for the string '{}'",
+            self.escape_char, self.escape_pos, self.handling_target
+        )
+    }
+}
+
+/// The error context of an unexpected escape character
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct EscapePosition {
+    pub handling_target: String,
+    pub escape_char: u8,
+    pub escape_pos: usize,
+}
+
+impl Display for EscapePosition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Unexpected escape character {}({:x}) at {} parsing '{}'",
+            char::from(self.escape_char),
+            self.escape_char,
+            self.escape_pos,
+            self.handling_target
+        )
+    }
+}
+
+/// The error context of a parsing error
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum ParseError {
+    ParsingError(Box<pest::error::Error<Rule>>),
+    UnexpectedEndOfSequence(EscapeEOS),
+    InvalidEscapeChar(EscapePosition),
+}
+
+impl From<EscapeEOS> for ParseError {
+    fn from(value: EscapeEOS) -> Self {
+        ParseError::UnexpectedEndOfSequence(value)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum AttrVal {
+    N(String),
+    S(String),
+    Bool(bool),
+    Null(bool),
+    B(Bytes),
+    L(Vec<AttrVal>),
+    M(HashMap<String, AttrVal>),
+    NS(Vec<String>),
+    SS(Vec<String>),
+    BS(Vec<Bytes>),
+}
+
+impl AttrVal {
+    fn convert_attribute_value(self) -> AttributeValue {
+        match self {
+            AttrVal::N(number) => AttributeValue {
+                n: Some(number),
+                ..Default::default()
+            },
+            AttrVal::S(str) => AttributeValue {
+                s: Some(str),
+                ..Default::default()
+            },
+            AttrVal::Bool(boolean) => AttributeValue {
+                bool: Some(boolean),
+                ..Default::default()
+            },
+            AttrVal::Null(isnull) => AttributeValue {
+                null: Some(isnull),
+                ..Default::default()
+            },
+            AttrVal::B(binary) => AttributeValue {
+                b: Some(binary),
+                ..Default::default()
+            },
+            AttrVal::L(list) => AttributeValue {
+                l: Some(
+                    list.into_iter()
+                        .map(|x| x.convert_attribute_value())
+                        .collect(),
+                ),
+                ..Default::default()
+            },
+            AttrVal::M(map) => AttributeValue {
+                m: Some(
+                    map.into_iter()
+                        .map(|(key, val)| (key, val.convert_attribute_value()))
+                        .collect(),
+                ),
+                ..Default::default()
+            },
+            AttrVal::NS(list) => AttributeValue {
+                ns: Some(list),
+                ..Default::default()
+            },
+            AttrVal::SS(list) => AttributeValue {
+                ss: Some(list),
+                ..Default::default()
+            },
+            AttrVal::BS(list) => AttributeValue {
+                bs: Some(list),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl From<AttrVal> for AttributeValue {
+    fn from(value: AttrVal) -> Self {
+        value.convert_attribute_value()
+    }
+}
+
+/// Parse internal of double quoted string.
+///
+/// It accepts escape characters as the following.
+///
+/// | Escape Sequence | Character Represented by Sequence |
+/// |-----------------|-----------------------------------|
+/// |       \0        | An ASCII NUL (X'00') character    |
+/// |       \r        | A carriage return character       |
+/// |       \n        | A newline (linefeed) character    |
+/// |       \t        | A tab character                   |
+/// |       \\\\      | A backslash (\\) character         |
+/// |       \\\"      | A double quote (") character      |
+/// |       \\\'      | A single quote (') character      |
+fn parse_internal_double_quote_string(str: &str) -> Result<String, EscapeEOS> {
+    let mut result = String::with_capacity(str.len());
+    let mut escaping = false;
+    let mut escaping_pos = 0;
+    for (pos, ch) in str.chars().enumerate() {
+        if escaping {
+            match ch {
+                '0' => result.push('\0'),
+                'r' => result.push('\r'),
+                'n' => result.push('\n'),
+                't' => result.push('\t'),
+                _ => result.push(ch),
+            }
+            escaping = false;
+        } else if ch == '\\' {
+            escaping_pos = pos;
+            escaping = true;
+        } else {
+            result.push(ch);
+        }
+    }
+    if escaping {
+        Err(EscapeEOS {
+            escape_pos: escaping_pos,
+            escape_char: '\\',
+            handling_target: str.to_owned(),
+        })
+    } else {
+        Ok(result)
+    }
+}
+
+/// Parse double quoted string which accepts escape sequence.
+fn parse_double_quote_literal(str: &str) -> Result<String, EscapeEOS> {
+    parse_internal_double_quote_string(&str[1..str.len() - 1])
+}
+
+/// Parse single quoted string as is.
+fn parse_single_quote_literal(str: &str) -> String {
+    str[1..str.len() - 1].to_owned()
+}
+
+/// Parse an internal of binary_literal.
+///
+/// We use the same semantics as rust byte literals, except that we accept multiple bytes.
+/// See: https://doc.rust-lang.org/reference/tokens.html#byte-literals
+fn parse_internal_binary_literal(str: &str) -> Result<Bytes, ParseError> {
+    let mut result = Vec::with_capacity(str.len());
+    enum State {
+        Normal,
+        StartEscape,
+        ByteEscapeFirstChar,
+        ByteEscapeSecondChar,
+    }
+    let mut state = State::Normal;
+    let mut byte = 0u8;
+    for (idx, ch) in str.bytes().enumerate() {
+        match state {
+            State::Normal => {
+                if ch == b'\\' {
+                    state = State::StartEscape;
+                } else {
+                    result.push(ch);
+                }
+            }
+            State::StartEscape => match ch {
+                b'n' => {
+                    result.push(b'\n');
+                    state = State::Normal;
+                }
+                b'r' => {
+                    result.push(b'\r');
+                    state = State::Normal;
+                }
+                b't' => {
+                    result.push(b'\t');
+                    state = State::Normal;
+                }
+                b'0' => {
+                    result.push(b'\0');
+                    state = State::Normal;
+                }
+                b'\\' | b'\'' | b'"' => {
+                    result.push(ch);
+                    state = State::Normal;
+                }
+                b'x' => state = State::ByteEscapeFirstChar,
+                _ => {
+                    return Err(ParseError::InvalidEscapeChar(EscapePosition {
+                        handling_target: str.to_owned(),
+                        escape_char: ch,
+                        escape_pos: idx,
+                    }));
+                }
+            },
+            State::ByteEscapeFirstChar => {
+                byte = hex_as_byte(str, idx, ch)?;
+                state = State::ByteEscapeSecondChar;
+            }
+            State::ByteEscapeSecondChar => {
+                let byte = byte << 4 | hex_as_byte(str, idx, ch)?;
+                result.push(byte);
+                state = State::Normal;
+            }
+        }
+    }
+    Ok(Bytes::from(result))
+}
+
+/// Parse a hex character as a byte.
+///
+/// `parsing_str` and `idx` are used to create an error.
+fn hex_as_byte(parsing_str: &str, idx: usize, ch: u8) -> Result<u8, ParseError> {
+    if ch.is_ascii_digit() {
+        Ok(ch - b'0')
+    } else if (b'A'..=b'F').contains(&ch) {
+        Ok(ch - b'A' + 10)
+    } else if (b'a'..=b'f').contains(&ch) {
+        Ok(ch - b'a' + 10)
+    } else {
+        Err(ParseError::InvalidEscapeChar(EscapePosition {
+            handling_target: parsing_str.to_owned(),
+            escape_char: ch,
+            escape_pos: idx,
+        }))
+    }
+}
+
+/// Parse binary literal.
+fn parse_binary_literal(str: &str) -> Result<Bytes, ParseError> {
+    parse_internal_binary_literal(&str[1..str.len() - 1])
+}
+
+/// Parse internal of binary_string.
+///
+/// We use same semantics as rust byte string literals.
+/// See: https://doc.rust-lang.org/reference/tokens.html#byte-string-literals
+fn parse_internal_binary_string(str: &str) -> Result<Bytes, ParseError> {
+    let mut result = Vec::with_capacity(str.len());
+    enum State {
+        Normal,
+        StartEscape,
+        ByteEscapeFirstChar,
+        ByteEscapeSecondChar,
+        SkipSpaces,
+    }
+    let mut state = State::Normal;
+    let mut byte = 0u8;
+    for (idx, ch) in str.bytes().enumerate() {
+        match state {
+            State::Normal => {
+                if ch == b'\\' {
+                    state = State::StartEscape;
+                } else {
+                    result.push(ch);
+                }
+            }
+            State::StartEscape => match ch {
+                b'n' => {
+                    result.push(b'\n');
+                    state = State::Normal;
+                }
+                b'r' => {
+                    result.push(b'\r');
+                    state = State::Normal;
+                }
+                b't' => {
+                    result.push(b'\t');
+                    state = State::Normal;
+                }
+                b'0' => {
+                    result.push(b'\0');
+                    state = State::Normal;
+                }
+                b'\\' | b'\'' | b'"' => {
+                    result.push(ch);
+                    state = State::Normal;
+                }
+                b'\r' | b'\n' => {
+                    state = State::SkipSpaces;
+                }
+                b'x' => state = State::ByteEscapeFirstChar,
+                _ => {
+                    return Err(ParseError::InvalidEscapeChar(EscapePosition {
+                        handling_target: str.to_owned(),
+                        escape_char: ch,
+                        escape_pos: idx,
+                    }));
+                }
+            },
+            State::SkipSpaces => match ch {
+                b' ' | b'\t' | b'\n' | b'\r' => {}
+                b'\\' => {
+                    state = State::StartEscape;
+                }
+                _ => {
+                    state = State::Normal;
+                    result.push(ch);
+                }
+            },
+            State::ByteEscapeFirstChar => {
+                byte = hex_as_byte(str, idx, ch)?;
+                state = State::ByteEscapeSecondChar;
+            }
+            State::ByteEscapeSecondChar => {
+                let byte = byte << 4 | hex_as_byte(str, idx, ch)?;
+                result.push(byte);
+                state = State::Normal;
+            }
+        }
+    }
+    Ok(Bytes::from(result))
+}
+
+/// Parse binary string literal.
+fn parse_binary_string_literal(str: &str) -> Result<Bytes, ParseError> {
+    parse_internal_binary_string(&str[1..str.len() - 1])
+}
+
+fn parse_string_literal(pair: Pair<Rule>) -> Result<String, ParseError> {
+    match pair.as_rule() {
+        Rule::double_quote_literal => Ok(parse_double_quote_literal(pair.as_str())?),
+        Rule::single_quote_literal => Ok(parse_single_quote_literal(pair.as_str())),
+        _ => {
+            // this must not happen
+            unreachable!("Expect string literal, but another token found");
+        }
+    }
+}
+
+fn parse_list_literal(pair: Pair<Rule>) -> Result<Vec<AttrVal>, ParseError> {
+    assert_eq!(pair.as_rule(), Rule::list_literal);
+    pair.into_inner().map(parse_literal).collect()
+}
+
+/// Parse a literal part
+fn parse_literal(pair: Pair<Rule>) -> Result<AttrVal, ParseError> {
+    match pair.as_rule() {
+        Rule::true_literal => Ok(AttrVal::Bool(true)),
+        Rule::false_literal => Ok(AttrVal::Bool(false)),
+        Rule::null_literal => Ok(AttrVal::Null(true)),
+        Rule::double_quote_literal | Rule::single_quote_literal => {
+            Ok(AttrVal::S(parse_string_literal(pair)?))
+        }
+        Rule::number_literal => Ok(AttrVal::N(pair.as_str().to_owned())),
+        Rule::binary_literal => Ok(AttrVal::B(parse_binary_literal(pair.as_str())?)),
+        Rule::binary_string_literal => Ok(AttrVal::B(parse_binary_string_literal(pair.as_str())?)),
+        Rule::list_literal => Ok(AttrVal::L(parse_list_literal(pair)?)),
+        Rule::map_literal => {
+            let map: Result<HashMap<_, _>, _> = pair
+                .into_inner()
+                .map(|p| {
+                    assert_eq!(p.as_rule(), Rule::map_pair);
+                    let it = p.into_inner();
+                    if let Some((p_key, p_val)) = it.collect_tuple() {
+                        assert_eq!(p_key.as_rule(), Rule::map_key);
+                        assert_eq!(p_val.as_rule(), Rule::map_value);
+                        // this unwrap is safe because map_key has always one string literal
+                        let key = parse_string_literal(p_key.into_inner().next().unwrap());
+                        key.and_then(|key| {
+                            // this unwrap is safe because map_value has always one literal
+                            let value = p_val.into_inner().next().unwrap();
+                            parse_literal(value).map(|x| (key.to_string(), x))
+                        })
+                    } else {
+                        // this must not happen
+                        unreachable!("Unexpected non-paired map element")
+                    }
+                })
+                .collect();
+            Ok(AttrVal::M(map?))
+        }
+        Rule::string_set_literal => {
+            let list: Result<Vec<_>, _> = pair
+                .into_inner()
+                .map(|p| {
+                    match p.as_rule() {
+                        Rule::double_quote_literal => parse_double_quote_literal(p.as_str()),
+                        Rule::single_quote_literal => Ok(parse_single_quote_literal(p.as_str())),
+                        _ => {
+                            // this must not happen
+                            unreachable!("Unexpected string set element")
+                        }
+                    }
+                })
+                .collect();
+            Ok(AttrVal::SS(list?))
+        }
+        Rule::number_set_literal => {
+            let list: Vec<_> = pair
+                .into_inner()
+                .map(|p| {
+                    match p.as_rule() {
+                        Rule::number_literal => p.as_str().to_string(),
+                        _ => {
+                            // this must not happen
+                            unreachable!("Unexpected number set element")
+                        }
+                    }
+                })
+                .collect();
+            Ok(AttrVal::NS(list))
+        }
+        Rule::binary_set_literal => {
+            let list: Result<Vec<_>, _> = pair
+                .into_inner()
+                .map(|p| {
+                    match p.as_rule() {
+                        Rule::binary_literal => parse_binary_literal(p.as_str()),
+                        Rule::binary_string_literal => parse_binary_string_literal(p.as_str()),
+                        _ => {
+                            // this must not happen
+                            unreachable!("Unexpected binary set element")
+                        }
+                    }
+                })
+                .collect();
+            Ok(AttrVal::BS(list?))
+        }
+        _ => {
+            // this must not happen
+            unreachable!("Unexpected element on literal")
+        }
+    }
+}
+
+fn parse_path(pair: Pair<Rule>) -> Path {
+    assert_eq!(pair.as_rule(), Rule::path);
+    let mut path = Path::new();
+    for p in pair.into_inner() {
+        match p.as_rule() {
+            Rule::non_quoted_identifier => {
+                path.add_attr(p.as_str().to_owned());
+            }
+            Rule::quoted_identifier => {
+                path.add_attr(p.as_str().to_owned().replace("``", "`"));
+            }
+            Rule::list_index_number => path.add_index(p.as_str().to_owned()),
+            _ => {
+                // this must not happen
+                unreachable!("Unexpected element on path")
+            }
+        }
+    }
+    path
+}
+
+fn parse_list_append_parameter(pair: Pair<Rule>) -> Result<ListAppendParameter, ParseError> {
+    assert_eq!(pair.as_rule(), Rule::list_append_parameter);
+    let pair = pair.into_inner().next().unwrap();
+    match pair.as_rule() {
+        Rule::path => Ok(ListAppendParameter::Path(parse_path(pair))),
+        Rule::list_literal => Ok(ListAppendParameter::ListLiteral(AttrVal::L(
+            parse_list_literal(pair)?,
+        ))),
+        _ => {
+            // this must not happen
+            unreachable!("Invalid parameter of list_append")
+        }
+    }
+}
+
+fn parse_function(pair: Pair<Rule>) -> Result<Function, ParseError> {
+    assert_eq!(pair.as_rule(), Rule::function);
+    // this unwrap is safe because function has exactly one children
+    let pair = pair.into_inner().next().unwrap();
+    match pair.as_rule() {
+        Rule::list_append_function => {
+            let mut pair = pair.into_inner();
+            let lhs = pair.next().unwrap();
+            let rhs = pair.next().unwrap();
+            let lhs_list = parse_list_append_parameter(lhs)?;
+            let rhs_list = parse_list_append_parameter(rhs)?;
+            Ok(Function::ListAppendFunction(lhs_list, rhs_list))
+        }
+        Rule::if_not_exists_function => {
+            let mut pair = pair.into_inner();
+            let path = pair.next().unwrap();
+            let value = pair.next().unwrap();
+            let path_expression = parse_path(path);
+            let value_expression = parse_value(value)?;
+            Ok(Function::IfNotExistsFunction(
+                path_expression,
+                Box::new(value_expression),
+            ))
+        }
+        _ => {
+            // this must not happen
+            unreachable!("Invalid function expression")
+        }
+    }
+}
+
+fn parse_operand(pair: Pair<Rule>) -> Result<Operand, ParseError> {
+    assert_eq!(pair.as_rule(), Rule::operand);
+    // this unwrap is safe because function has exactly one children
+    let pair = pair.into_inner().next().unwrap();
+    match pair.as_rule() {
+        Rule::function => Ok(Operand::Function(parse_function(pair)?)),
+        Rule::path => Ok(Operand::Path(parse_path(pair))),
+        _ => Ok(Operand::Literal(parse_literal(pair)?)),
+    }
+}
+
+fn parse_value(pair: Pair<Rule>) -> Result<Value, ParseError> {
+    assert_eq!(pair.as_rule(), Rule::value);
+    // this unwrap is safe because value has exactly one children
+    let pair = pair.into_inner().next().unwrap();
+    match pair.as_rule() {
+        Rule::plus_expression => {
+            if let Some((lhs, rhs)) = pair.into_inner().collect_tuple() {
+                let lhs = parse_operand(lhs)?;
+                let rhs = parse_operand(rhs)?;
+                Ok(Value::PlusExpression(lhs, rhs))
+            } else {
+                // this must not happen
+                unreachable!("Invalid plus expression is detected");
+            }
+        }
+        Rule::minus_expression => {
+            if let Some((lhs, rhs)) = pair.into_inner().collect_tuple() {
+                let lhs = parse_operand(lhs)?;
+                let rhs = parse_operand(rhs)?;
+                Ok(Value::MinusExpression(lhs, rhs))
+            } else {
+                // this must not happen
+                unreachable!("Invalid plus expression is detected");
+            }
+        }
+        Rule::operand => Ok(Value::Operand(parse_operand(pair)?)),
+        _ => {
+            // this must not happen
+            unreachable!("Unexpected expression is detected");
+        }
+    }
+}
+
+fn parse_remove_action_pair(pair: Pair<Rule>) -> RemoveAction {
+    assert_eq!(pair.as_rule(), Rule::remove_action);
+    let mut remove_actions = Vec::new();
+    for pair in pair.into_inner() {
+        let path = parse_path(pair);
+        remove_actions.push(AtomicRemove { path })
+    }
+    remove_actions
+}
+
+fn parse_set_action_pair(pair: Pair<Rule>) -> Result<SetAction, ParseError> {
+    assert_eq!(pair.as_rule(), Rule::set_action);
+    let mut set_actions = Vec::new();
+    for chunk in pair.into_inner().chunks(2).into_iter() {
+        if let Some((path, value)) = chunk.collect_tuple() {
+            let path = parse_path(path);
+            let value = parse_value(value)?;
+            set_actions.push(AtomicSet { path, value });
+        } else {
+            // this must not happen
+            unreachable!("Unpaired set action is detected")
+        }
+    }
+    Ok(set_actions)
+}
+
+fn attr_name_ref(idx: usize) -> String {
+    format!("#DYNEIN_ATTRNAME{}", idx)
+}
+
+fn attr_val_ref(idx: usize) -> String {
+    format!(":DYNEIN_ATTRVAL{}", idx)
+}
+
+/// The parser for dynein.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DyneinParser {
+    names: HashMap<String, String>,
+    names_inv: HashMap<String, String>,
+    values: HashMap<String, AttributeValue>,
+}
+
+impl DyneinParser {
+    /// Create a new parser.
+    ///
+    /// The created parser has a context for API calls, `ExpressionAttributeNames` and `ExpressionAttributeValues`.
+    /// These contexts can be shared by multiple actions.
+    pub fn new() -> DyneinParser {
+        DyneinParser {
+            names: HashMap::new(),
+            names_inv: HashMap::new(),
+            values: HashMap::new(),
+        }
+    }
+
+    /// Parse set actions.
+    ///
+    /// You can call this more than once.
+    /// In this case, you have a responsibility to merge the `exp` of [`ExpressionResult`].
+    pub fn parse_set_action(&mut self, exp: &str) -> Result<ExpressionResult, ParseError> {
+        let result = GeneratedParser::parse(Rule::set_action, exp);
+        match result {
+            Ok(mut pair) => {
+                let set_action = parse_set_action_pair(pair.next().unwrap())?;
+                self.process_set_action(set_action)
+            }
+            Err(err) => Err(ParseError::ParsingError(Box::new(err))),
+        }
+    }
+
+    /// Parse remove actions.
+    ///
+    /// You can call this more than once.
+    /// In this case, you have a responsibility to merge the `exp` of [`ExpressionResult`].
+    pub fn parse_remove_action(&mut self, exp: &str) -> Result<ExpressionResult, ParseError> {
+        let result = GeneratedParser::parse(Rule::remove_action, exp);
+        match result {
+            Ok(mut pair) => {
+                let remove_action = parse_remove_action_pair(pair.next().unwrap());
+                self.process_remove_action(remove_action)
+            }
+            Err(err) => Err(ParseError::ParsingError(Box::new(err))),
+        }
+    }
+
+    fn get_or_create_attr_name_ref(&mut self, attr_name: String) -> String {
+        match self.names_inv.entry(attr_name.to_owned()) {
+            Entry::Occupied(o) => o.get().to_owned(),
+            Entry::Vacant(v) => {
+                let ref_name = attr_name_ref(self.names.len());
+                v.insert(ref_name.to_owned());
+                self.names.insert(ref_name.to_owned(), attr_name);
+                ref_name
+            }
+        }
+    }
+
+    fn add_value_and_return_ref(&mut self, value: AttrVal) -> String {
+        let idx = self.values.len();
+        let ref_name = attr_val_ref(idx);
+        let value = value.convert_attribute_value();
+        self.values.insert(ref_name.to_owned(), value);
+        ref_name
+    }
+
+    fn process_path(&mut self, input: Path) -> String {
+        let mut expression = String::new();
+        let mut is_first = true;
+        for elem in input.elements {
+            match elem {
+                PathElement::Attribute(name) => {
+                    let name_ref = self.get_or_create_attr_name_ref(name);
+                    if is_first {
+                        expression.push_str(&name_ref);
+                        is_first = false;
+                    } else {
+                        expression.push('.');
+                        expression.push_str(&name_ref)
+                    }
+                }
+                PathElement::Index(idx) => {
+                    expression.push('[');
+                    expression.push_str(&idx);
+                    expression.push(']');
+                }
+            }
+        }
+        expression
+    }
+
+    fn process_literal(&mut self, input: AttrVal) -> Result<String, ParseError> {
+        Ok(self.add_value_and_return_ref(input))
+    }
+
+    fn process_list_append_parameter(
+        &mut self,
+        input: ListAppendParameter,
+    ) -> Result<String, ParseError> {
+        match input {
+            ListAppendParameter::Path(path) => Ok(self.process_path(path)),
+            ListAppendParameter::ListLiteral(literal) => self.process_literal(literal),
+        }
+    }
+
+    fn process_function(&mut self, input: Function) -> Result<String, ParseError> {
+        match input {
+            Function::ListAppendFunction(lhs, rhs) => {
+                let mut expression = "list_append(".to_owned();
+                let lhs = self.process_list_append_parameter(lhs)?;
+                let rhs = self.process_list_append_parameter(rhs)?;
+                expression.push_str(&lhs);
+                expression.push(',');
+                expression.push_str(&rhs);
+                expression.push(')');
+                Ok(expression)
+            }
+            Function::IfNotExistsFunction(path, value) => {
+                let mut expression = "if_not_exists(".to_owned();
+                let path_expression = self.process_path(path);
+                let value_expression = self.process_value(*value)?;
+                expression.push_str(&path_expression);
+                expression.push(',');
+                expression.push_str(&value_expression);
+                expression.push(')');
+                Ok(expression)
+            }
+        }
+    }
+
+    fn process_operand(&mut self, input: Operand) -> Result<String, ParseError> {
+        match input {
+            Operand::Function(function) => self.process_function(function),
+            Operand::Literal(literal) => self.process_literal(literal),
+            Operand::Path(path) => Ok(self.process_path(path)),
+        }
+    }
+
+    fn process_value(&mut self, input: Value) -> Result<String, ParseError> {
+        match input {
+            Value::PlusExpression(lhs, rhs) => {
+                let mut lhs = self.process_operand(lhs)?;
+                let rhs = self.process_operand(rhs)?;
+                lhs.push('+');
+                lhs.push_str(&rhs);
+                Ok(lhs)
+            }
+            Value::MinusExpression(lhs, rhs) => {
+                let mut lhs = self.process_operand(lhs)?;
+                let rhs = self.process_operand(rhs)?;
+                lhs.push('-');
+                lhs.push_str(&rhs);
+                Ok(lhs)
+            }
+            Value::Operand(op) => self.process_operand(op),
+        }
+    }
+
+    fn process_set_action(&mut self, input: SetAction) -> Result<ExpressionResult, ParseError> {
+        let mut expression = String::new();
+        for set in input {
+            let path = self.process_path(set.path);
+            let value = self.process_value(set.value)?;
+            if !expression.is_empty() {
+                expression.push(',');
+            }
+            expression.push_str(&path);
+            expression.push('=');
+            expression.push_str(&value);
+        }
+        Ok(ExpressionResult {
+            exp: expression.to_owned(),
+            names: self.names.clone(),
+            values: self.values.clone(),
+        })
+    }
+
+    fn process_remove_action(
+        &mut self,
+        input: RemoveAction,
+    ) -> Result<ExpressionResult, ParseError> {
+        let mut expression = String::new();
+        for remove in input {
+            let path = self.process_path(remove.path);
+            if !expression.is_empty() {
+                expression.push(',');
+            }
+            expression.push_str(&path);
+        }
+        Ok(ExpressionResult {
+            exp: expression.to_owned(),
+            names: self.names.clone(),
+            values: self.values.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_internal_double_quote_string() {
+        assert_eq!(parse_internal_double_quote_string("a").unwrap(), "a");
+        assert_eq!(parse_internal_double_quote_string("\\0").unwrap(), "\0");
+        assert_eq!(
+            parse_internal_double_quote_string("\\r\\n").unwrap(),
+            "\r\n"
+        );
+        assert_eq!(parse_internal_double_quote_string("\\r").unwrap(), "\r");
+        assert_eq!(parse_internal_double_quote_string("\\n").unwrap(), "\n");
+        assert_eq!(parse_internal_double_quote_string("\\t").unwrap(), "\t");
+        assert_eq!(parse_internal_double_quote_string("\\\\").unwrap(), "\\");
+        assert_eq!(parse_internal_double_quote_string("\\'").unwrap(), "'");
+        assert_eq!(parse_internal_double_quote_string("\\\"").unwrap(), "\"");
+        assert_eq!(parse_internal_double_quote_string("\0").unwrap(), "\0");
+        assert_eq!(parse_internal_double_quote_string("\r\n").unwrap(), "\r\n");
+        assert_eq!(parse_internal_double_quote_string("\r").unwrap(), "\r");
+        assert_eq!(parse_internal_double_quote_string("\n").unwrap(), "\n");
+        assert_eq!(parse_internal_double_quote_string("\t").unwrap(), "\t");
+        assert_eq!(
+            parse_internal_double_quote_string("\\").expect_err("It must not Ok()"),
+            EscapeEOS {
+                handling_target: "\\".to_owned(),
+                escape_pos: 0,
+                escape_char: '\\',
+            }
+        );
+        assert_eq!(parse_internal_double_quote_string("'").unwrap(), "'");
+        assert_eq!(parse_internal_double_quote_string("\"").unwrap(), "\"");
+        assert_eq!(
+            parse_internal_double_quote_string("This is a line.\\nこれは行です。").unwrap(),
+            "This is a line.\nこれは行です。"
+        );
+    }
+
+    #[test]
+    fn test_parse_single_quote_literal() {
+        assert_eq!(parse_single_quote_literal("'a'"), "a");
+        assert_eq!(parse_single_quote_literal("'\\0'"), "\\0");
+        assert_eq!(parse_single_quote_literal("'\\r\\n'"), "\\r\\n");
+        assert_eq!(parse_single_quote_literal("'\\r'"), "\\r");
+        assert_eq!(parse_single_quote_literal("'\\n'"), "\\n");
+        assert_eq!(parse_single_quote_literal("'\\t'"), "\\t");
+        assert_eq!(parse_single_quote_literal("'\\\\'"), "\\\\");
+        assert_eq!(parse_single_quote_literal("'\\''"), "\\'");
+        assert_eq!(parse_single_quote_literal("'\\\"'"), "\\\"");
+    }
+
+    #[test]
+    fn test_hex_as_byte() {
+        assert_eq!(hex_as_byte("0", 0, b'0').unwrap(), 0);
+        assert_eq!(hex_as_byte("9", 0, b'9').unwrap(), 9);
+        assert_eq!(hex_as_byte("a", 0, b'a').unwrap(), 10);
+        assert_eq!(hex_as_byte("f", 0, b'f').unwrap(), 15);
+        assert_eq!(
+            hex_as_byte("g", 0, b'g').unwrap_err(),
+            ParseError::InvalidEscapeChar(EscapePosition {
+                handling_target: "g".to_owned(),
+                escape_pos: 0,
+                escape_char: b'g',
+            })
+        );
+        assert_eq!(
+            hex_as_byte("dummy", 0, b'\xff').unwrap_err(),
+            ParseError::InvalidEscapeChar(EscapePosition {
+                handling_target: "dummy".to_owned(),
+                escape_pos: 0,
+                escape_char: b'\xff',
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_internal_binary_literal() {
+        assert_eq!(
+            parse_internal_binary_literal("\\xDE\\xAD\\xbe\\xef").unwrap(),
+            Bytes::from_static(b"\xde\xad\xbe\xef")
+        );
+        assert_eq!(
+            parse_internal_binary_literal("\\n\\r\\t\\\\\\0\\'\\\"").unwrap(),
+            Bytes::from_static(b"\n\r\t\\\0\'\"")
+        );
+        assert_eq!(
+            parse_internal_binary_literal("\\xZZ").unwrap_err(),
+            ParseError::InvalidEscapeChar(EscapePosition {
+                handling_target: "\\xZZ".to_owned(),
+                escape_pos: 2,
+                escape_char: b'Z',
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_internal_binary_string() {
+        let binary_string = "a\\\n\r\n\t b\\\r\r\n\t c\\xDE\\xAD\\xbe\\xef\\r\\n\\t\\\\\\0\\'\\\"";
+        let expect_binary = b"abc\xde\xad\xbe\xef\r\n\t\\\0'\"";
+        assert_eq!(
+            parse_internal_binary_string(binary_string).unwrap(),
+            Bytes::from_static(expect_binary)
+        );
+    }
+
+    #[test]
+    fn test_parse_literal() {
+        // boolean literal
+        let parsed_result = GeneratedParser::parse(Rule::literal, "true")
+            .unwrap()
+            .next()
+            .unwrap();
+        let true_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(true_literal, AttrVal::Bool(true));
+
+        let parsed_result = GeneratedParser::parse(Rule::literal, "false")
+            .unwrap()
+            .next()
+            .unwrap();
+        let false_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(false_literal, AttrVal::Bool(false));
+
+        // null literal
+        let parsed_result = GeneratedParser::parse(Rule::literal, "null")
+            .unwrap()
+            .next()
+            .unwrap();
+        let null_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(null_literal, AttrVal::Null(true));
+
+        // double quoted string literal
+        let parsed_result = GeneratedParser::parse(Rule::literal, "\"🍣 is \\\"sushi\\\"!\"")
+            .unwrap()
+            .next()
+            .unwrap();
+        let sushi_string = parse_literal(parsed_result).unwrap();
+        assert_eq!(sushi_string, AttrVal::S("🍣 is \"sushi\"!".to_owned()));
+
+        let parsed_result = GeneratedParser::parse(Rule::literal, "\"\\0\\r\\n\\t\\\\\\\"\\'\"")
+            .unwrap()
+            .next()
+            .unwrap();
+        let all_escape_string = parse_literal(parsed_result).unwrap();
+        assert_eq!(all_escape_string, AttrVal::S("\0\r\n\t\\\"\'".to_owned()));
+
+        // single quoted string literal
+        let parsed_result = GeneratedParser::parse(Rule::literal, "'Escape must not work\\n'")
+            .unwrap()
+            .next()
+            .unwrap();
+        let raw_string = parse_literal(parsed_result).unwrap();
+        assert_eq!(raw_string, AttrVal::S("Escape must not work\\n".to_owned()));
+
+        // number literal
+        let num_list = [
+            "12345678901234567890",
+            "0",
+            "+1",
+            "-1",
+            "+0",
+            "-0",
+            "+0.0",
+            "-0.0",
+            "3.141592653589793238462643",
+            "+1.1",
+            "-1.1",
+            ".1",
+            "1.",
+            "0.0",
+            "0.",
+            ".0",
+            "-2.71828182846e-12",
+            "1e1",
+            "+1e+1",
+            "-1e-1",
+            "1e0",
+            "0e1",
+            "0e0", // 0e0 = 0 in DynamoDB
+            "1E-130",
+            "9.9999999999999999999999999999999999999E+125",
+            "-9.9999999999999999999999999999999999999E+125",
+            "-1E-130",
+        ];
+        for num in num_list {
+            let parsed_result = GeneratedParser::parse(Rule::literal, num)
+                .unwrap()
+                .next()
+                .unwrap();
+            let pi_number = parse_literal(parsed_result).unwrap();
+            assert_eq!(pi_number, AttrVal::N(num.to_owned()));
+        }
+
+        // list literal
+        let parsed_result = GeneratedParser::parse(Rule::literal, "[1,'2', true]")
+            .unwrap()
+            .next()
+            .unwrap();
+        let list_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(
+            list_literal,
+            AttrVal::L(Vec::from([
+                AttrVal::N("1".to_owned()),
+                AttrVal::S("2".to_owned()),
+                AttrVal::Bool(true),
+            ]))
+        );
+
+        // map literal
+        let parsed_result = GeneratedParser::parse(
+            Rule::literal,
+            "{'1': \"id1\", \"2\": 4, '3': true, 's 1': null}",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+        let map_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(
+            map_literal,
+            AttrVal::M(HashMap::from([
+                ("1".to_owned(), AttrVal::S("id1".to_owned())),
+                ("2".to_owned(), AttrVal::N("4".to_owned())),
+                ("3".to_owned(), AttrVal::Bool(true)),
+                ("s 1".to_owned(), AttrVal::Null(true)),
+            ]))
+        );
+
+        // binary literal
+        let parsed_result = GeneratedParser::parse(
+            Rule::literal,
+            "b'\\xDE\\xAD\\xbe\\xef\\n\\r\\t\\\\\0\\'\\\"'",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+        let binary_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(
+            binary_literal,
+            AttrVal::B(Bytes::from_static(b"\xde\xad\xbe\xef\n\r\t\\\0\'\""))
+        );
+
+        // binary string literal
+        let parsed_result = GeneratedParser::parse(
+            Rule::literal,
+            "b\"\\xDE\\xAD\\xbe\\xef\\\n\r\t\\\\\0\\'\\\"\"",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+        let binary_string = parse_literal(parsed_result).unwrap();
+        assert_eq!(
+            binary_string,
+            AttrVal::B(Bytes::from_static(b"\xde\xad\xbe\xef\\\0\'\""))
+        );
+
+        // string set literal
+        let parsed_result = GeneratedParser::parse(Rule::literal, "<<'S1',\"S 2\">>")
+            .unwrap()
+            .next()
+            .unwrap();
+        let string_set_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(
+            string_set_literal,
+            AttrVal::SS(Vec::from(["S1".to_owned(), "S 2".to_owned(),]))
+        );
+
+        // number set literal
+        let parsed_result = GeneratedParser::parse(Rule::literal, "<<0,-3,1.570,-1e3>>")
+            .unwrap()
+            .next()
+            .unwrap();
+        let string_set_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(
+            string_set_literal,
+            AttrVal::NS(Vec::from([
+                "0".to_owned(),
+                "-3".to_owned(),
+                "1.570".to_owned(),
+                "-1e3".to_owned(),
+            ]))
+        );
+
+        // binary set literal
+        let binary_list =
+            "<<b'deadbeef',b'\\xde\\xad\\xbe\\xef',b\"wa\\\n\trp\",b\"no-\n\twarp\">>";
+        let parsed_result = GeneratedParser::parse(Rule::literal, binary_list);
+        let binary_set_literal = parse_literal(parsed_result.unwrap().next().unwrap()).unwrap();
+        assert_eq!(
+            binary_set_literal,
+            AttrVal::BS(Vec::from([
+                Bytes::from_static(b"deadbeef"),
+                Bytes::from_static(b"\xde\xad\xbe\xef"),
+                Bytes::from_static(b"warp"),
+                Bytes::from_static(b"no-\n\twarp"),
+            ]))
+        );
+
+        // nested literal
+        let literal_input = "{'id': '123456', 'year': 2023, 'info': {'creators':['Alice', 'Bob']}}";
+        let parsed_result = GeneratedParser::parse(Rule::literal, literal_input)
+            .unwrap()
+            .next()
+            .unwrap();
+        let map_literal = parse_literal(parsed_result).unwrap();
+        assert_eq!(
+            map_literal,
+            AttrVal::M(HashMap::from([
+                ("id".to_owned(), AttrVal::S("123456".to_owned())),
+                ("year".to_owned(), AttrVal::N("2023".to_owned())),
+                (
+                    "info".to_owned(),
+                    AttrVal::M(HashMap::from([(
+                        "creators".to_owned(),
+                        AttrVal::L(Vec::from([
+                            AttrVal::S("Alice".to_owned()),
+                            AttrVal::S("Bob".to_owned()),
+                        ]))
+                    )]))
+                ),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_process_path() {
+        let path_parsed = GeneratedParser::parse(Rule::path, "a0.a1[1][2].`a 2`[2].a三.`a``4`.a0")
+            .unwrap()
+            .next()
+            .unwrap();
+        let result = parse_path(path_parsed);
+        let mut expected = Path::new();
+        expected.add_attr("a0".to_owned());
+        expected.add_attr("a1".to_owned());
+        expected.add_index("1".to_owned());
+        expected.add_index("2".to_owned());
+        expected.add_attr("a 2".to_owned());
+        expected.add_index("2".to_owned());
+        expected.add_attr("a三".to_owned());
+        expected.add_attr("a`4".to_owned());
+        expected.add_attr("a0".to_owned());
+        assert_eq!(result, expected);
+
+        let mut parser = DyneinParser::new();
+        let result = parser.process_path(result);
+        assert_eq!(
+            result,
+            format!(
+                "{}.{}[1][2].{}[2].{}.{}.{}",
+                attr_name_ref(0),
+                attr_name_ref(1),
+                attr_name_ref(2),
+                attr_name_ref(3),
+                attr_name_ref(4),
+                attr_name_ref(0)
+            )
+        );
+        assert_eq!(
+            parser.names,
+            HashMap::from([
+                (attr_name_ref(0), "a0".to_owned()),
+                (attr_name_ref(1), "a1".to_owned()),
+                (attr_name_ref(2), "a 2".to_owned()),
+                (attr_name_ref(3), "a三".to_owned()),
+                (attr_name_ref(4), "a`4".to_owned()),
+            ])
+        );
+        assert_eq!(parser.values, HashMap::new());
+    }
+
+    #[test]
+    fn test_process_literal() {
+        macro_rules! do_test {
+            ($in:expr, $expected:expr) => {{
+                let mut parser = DyneinParser::new();
+                let result = parser.process_literal($in).unwrap();
+                assert_eq!(result, attr_val_ref(0));
+                assert_eq!(parser.names, HashMap::new());
+                assert_eq!(parser.values, HashMap::from([(attr_val_ref(0), $expected)]));
+            }};
+        }
+
+        do_test!(
+            AttrVal::N("123".to_owned()),
+            AttributeValue {
+                n: Some("123".to_owned()),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::S("string".to_owned()),
+            AttributeValue {
+                s: Some("string".to_owned()),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::Bool(true),
+            AttributeValue {
+                bool: Some(true),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::Bool(false),
+            AttributeValue {
+                bool: Some(false),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::Null(true),
+            AttributeValue {
+                null: Some(true),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::B(Bytes::from_static(b"123")),
+            AttributeValue {
+                b: Some(Bytes::from_static(b"123")),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::L(vec![AttrVal::N("123".to_owned())]),
+            AttributeValue {
+                l: Some(vec![AttributeValue {
+                    n: Some("123".to_owned()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::M(HashMap::from([(
+                "m".to_owned(),
+                AttrVal::N("123".to_owned()),
+            )])),
+            AttributeValue {
+                m: Some(HashMap::from([(
+                    "m".to_owned(),
+                    AttributeValue {
+                        n: Some("123".to_owned()),
+                        ..Default::default()
+                    }
+                )])),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::NS(vec!["123".to_owned()]),
+            AttributeValue {
+                ns: Some(vec!["123".to_owned()]),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::SS(vec!["123".to_owned()]),
+            AttributeValue {
+                ss: Some(vec!["123".to_owned()]),
+                ..Default::default()
+            }
+        );
+        do_test!(
+            AttrVal::BS(vec![Bytes::from_static(b"123")]),
+            AttributeValue {
+                bs: Some(vec![Bytes::from_static(b"123")]),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_set_action() {
+        let mut parser = DyneinParser::new();
+        assert_eq!(
+            parser.parse_set_action("id = \"string\"").unwrap(),
+            ExpressionResult {
+                exp: format!("{}={}", attr_name_ref(0), attr_val_ref(0)),
+                names: HashMap::from([(attr_name_ref(0), "id".to_owned())]),
+                values: HashMap::from([(
+                    attr_val_ref(0),
+                    AttributeValue {
+                        s: Some("string".to_owned()),
+                        ..Default::default()
+                    }
+                )]),
+            }
+        );
+    }
+
+    #[test]
+    fn test_remove_action() {
+        let mut parser = DyneinParser::new();
+        assert_eq!(
+            parser
+                .parse_remove_action("p0, p1[0], p2.p3[1].p0")
+                .unwrap(),
+            ExpressionResult {
+                exp: format!(
+                    "{},{}[0],{}.{}[1].{}",
+                    attr_name_ref(0),
+                    attr_name_ref(1),
+                    attr_name_ref(2),
+                    attr_name_ref(3),
+                    attr_name_ref(0)
+                ),
+                names: HashMap::from([
+                    (attr_name_ref(0), "p0".to_owned()),
+                    (attr_name_ref(1), "p1".to_owned()),
+                    (attr_name_ref(2), "p2".to_owned()),
+                    (attr_name_ref(3), "p3".to_owned()),
+                ]),
+                values: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_set_and_remove_action() {
+        let mut parser = DyneinParser::new();
+        let names = HashMap::from([(attr_name_ref(0), "p0".to_owned())]);
+        let values = HashMap::from([(
+            attr_val_ref(0),
+            AttributeValue {
+                s: Some("string".to_owned()),
+                ..Default::default()
+            },
+        )]);
+        assert_eq!(
+            parser.parse_set_action("p0 = \"string\"").unwrap(),
+            ExpressionResult {
+                exp: format!("{}={}", attr_name_ref(0), attr_val_ref(0)),
+                names: names.to_owned(),
+                values: values.to_owned(),
+            }
+        );
+        assert_eq!(
+            parser.parse_remove_action("p0").unwrap(),
+            ExpressionResult {
+                exp: attr_name_ref(0),
+                names,
+                values,
+            }
+        );
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

* #92
* #82

*Description of changes:*
This PR implements correct parsing for `UpdateItem` API (`upd` command) using [pest](https://pest.rs/). This also contains the following feature enhancements and bug fixes.

* Support a binary type.
* Support a single quotes for a string type.
* Support list_append and if_not_exists function.
* Support spcifying a list element as a path.
* No longer fail when a expression containing hyphens, commas, indexing, etc.

But, it introduces a breaking change.

* A list type is no longer classified automatically based on its element type. The current behavior is described in [dispatch_jsonvalue_to_attrval function](https://github.com/awslabs/dynein/blob/5eb664559bee22f5e4f7931ed5310d47d9d68f36/src/data.rs#L828-L845)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
