### PR TITLE
refactor: refactor some points related to rusoto_dynamodb

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,10 +16,7 @@
 
 use ::serde::{Deserialize, Serialize};
 use log::{debug, error, info};
-use rusoto_dynamodb::{
-    AttributeDefinition, DescribeTableInput, DynamoDb, DynamoDbClient, KeySchemaElement,
-    TableDescription,
-};
+use rusoto_dynamodb::{AttributeDefinition, KeySchemaElement, TableDescription};
 use rusoto_signature::Region;
 use serde_yaml::Error as SerdeYAMLError;
 use std::{
@@ -442,7 +439,7 @@ pub async fn use_table(
             debug!("describing the table: {}", tbl);
             let region = cx.effective_region();
             let tbl = tbl.clone();
-            let desc: TableDescription = describe_table_api(&region, tbl.clone()).await;
+            let desc: TableDescription = control::describe_table_api(&region, tbl.clone()).await;
             save_using_target(cx, desc)?;
             println!("Now you're using the table '{}' ({}).", tbl, &region.name());
         },
@@ -555,7 +552,7 @@ pub async fn table_schema(cx: &Context) -> TableSchema {
         // It's possible that users pass --table without calling `dy use` for any table. Thus collect all data from DescribeTable results.
         Some(table_name) => {
             // TODO: reduce # of DescribeTable API calls. table_schema function is called every time you do something.
-            let desc: TableDescription = describe_table_api(
+            let desc: TableDescription = control::describe_table_api(
                 &cx.effective_region(),
                 table_name, /* should be equal to 'cx.effective_table_name()' */
             )
@@ -622,26 +619,6 @@ pub fn index_schemas(desc: &TableDescription) -> Option<Vec<IndexSchema>> {
         None
     } else {
         Some(indexes)
-    }
-}
-
-/// Originally intended to be called by describe_table function, which is called from `$ dy desc`,
-/// however it turned out that DescribeTable API result is useful in various logic, separated API into this standalone function.
-pub async fn describe_table_api(region: &Region, table_name: String) -> TableDescription {
-    let ddb = DynamoDbClient::new(region.clone());
-    let req: DescribeTableInput = DescribeTableInput { table_name };
-
-    match ddb.describe_table(req).await {
-        Err(e) => {
-            debug!("DescribeTable API call got an error -- {:#?}", e);
-            error!("{}", e.to_string());
-            std::process::exit(1);
-        }
-        Ok(res) => {
-            let desc: TableDescription = res.table.expect("This message should not be shown.");
-            debug!("Received DescribeTable Result: {:?}\n", desc);
-            desc
-        }
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,10 @@
 
 use ::serde::{Deserialize, Serialize};
 use log::{debug, error, info};
-use rusoto_dynamodb::*;
+use rusoto_dynamodb::{
+    AttributeDefinition, DescribeTableInput, DynamoDb, DynamoDbClient, KeySchemaElement,
+    TableDescription,
+};
 use rusoto_signature::Region;
 use serde_yaml::Error as SerdeYAMLError;
 use std::{

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -16,7 +16,10 @@
 
 use log::{debug, error};
 use rusoto_core::RusotoError;
-use rusoto_dynamodb::*;
+use rusoto_dynamodb::{
+    AttributeValue, BatchWriteItemError, BatchWriteItemInput, DeleteRequest, DynamoDb,
+    DynamoDbClient, PutRequest, WriteRequest,
+};
 use serde_json::Value as JsonValue;
 use std::{collections::HashMap, error, fmt, fs, future::Future, io::Error as IOError, pin::Pin};
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -421,7 +421,7 @@ async fn wait_table_creation(cx: &app::Context, mut processing_tables: Vec<&str>
         let create_table_results = join_all(
             processing_tables
                 .iter()
-                .map(|t| app::describe_table_api(r, (*t).to_string())),
+                .map(|t| control::describe_table_api(r, (*t).to_string())),
         )
         .await;
         let statuses: Vec<String> = create_table_results

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -26,7 +26,9 @@ use std::{
 use futures::future::join_all;
 use log::{debug, error};
 use rusoto_core::RusotoError;
-use rusoto_dynamodb::*;
+use rusoto_dynamodb::{
+    AttributeValue, BatchWriteItemError, CreateTableError, PutRequest, WriteRequest,
+};
 use rusoto_signature::Region;
 use tempfile::Builder;
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -19,7 +19,14 @@ use ::serde::{Deserialize, Serialize};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use futures::future::join_all;
 use log::{debug, error};
-use rusoto_dynamodb::*;
+use rusoto_dynamodb::{
+    AttributeDefinition, BackupSummary, BillingModeSummary, CreateBackupInput,
+    CreateGlobalSecondaryIndexAction, CreateTableInput, DeleteTableInput, DynamoDb, DynamoDbClient,
+    GlobalSecondaryIndexDescription, GlobalSecondaryIndexUpdate, KeySchemaElement,
+    ListBackupsInput, ListTablesInput, LocalSecondaryIndexDescription, Projection,
+    ProvisionedThroughput, ProvisionedThroughputDescription, RestoreTableFromBackupInput,
+    StreamSpecification, TableDescription, UpdateTableInput,
+};
 use rusoto_ec2::{DescribeRegionsRequest, Ec2, Ec2Client};
 use rusoto_signature::Region;
 use std::{

--- a/src/data.rs
+++ b/src/data.rs
@@ -25,7 +25,10 @@ use std::{
 
 use log::{debug, error};
 use regex::Regex;
-use rusoto_dynamodb::*;
+use rusoto_dynamodb::{
+    AttributeValue, DeleteItemInput, DynamoDb, DynamoDbClient, GetItemInput, PutItemInput,
+    QueryInput, ScanInput, ScanOutput, UpdateItemInput,
+};
 use serde_json::Value as JsonValue;
 use tabwriter::TabWriter;
 // use bytes::Bytes;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -25,7 +25,7 @@ use dialoguer::Confirm;
 use log::{debug, error};
 use serde_json::{de::StrRead, Deserializer, StreamDeserializer, Value as JsonValue};
 
-use rusoto_dynamodb::*;
+use rusoto_dynamodb::{AttributeValue, ScanOutput, WriteRequest};
 
 use super::app;
 use super::batch;


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

- Using wildcard import is hard to understand what kind of struct is used in general. Also the crate has same name struct with AWS SDK for Rust. It causes to take time to migrate it.
- move describe_table_api to control

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
