### PR TITLE
feat: show the number of processed items in import/export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,15 +305,15 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -571,6 +571,7 @@ dependencies = [
  "atty",
  "bytes",
  "chrono",
+ "console",
  "dialoguer",
  "dirs",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ pest = "2.6.0"
 pest_derive = "2.6.0"
 bytes = "1.4.0"
 itertools = "0.10.5"
+console = "0.15.7"
 
 [dev-dependencies]
 assert_cmd = "2.0.2" # contains helpers make executing the main binary on integration tests easier.


### PR DESCRIPTION
*Issue #, if available:*
Partial implementation for #91.

*Description of changes:*
This pull request aims to partially resolve #91 by providing the current number of completed items. The calculation for item size requires additional work and depends on the SDK, which is currently undergoing changes. Therefore, I implemented this without the information on sizes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
