### PR TITLE
test: add integration test for get

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "predicates 2.1.5",
+ "rand",
  "regex",
  "reqwest",
  "rusoto_core",
@@ -1466,6 +1467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "predicates"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,10 +1557,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rayon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ assert_cmd = "2.0.2" # contains helpers make executing the main binary on integr
 predicates = "2.0.3" # to introduce advanced assertions
 once_cell = "1.9.0" # to setup docker container syncrhonously
 trycmd = "0.14.16" # snapshot testing for CLI
+rand = "0.8.5"
 
 [build-dependencies]
 # Unless the "version_check" build dependency, proc-macro-error-attr v1.0.4 build would fail.

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -1,0 +1,168 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod util;
+
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Used for writing assertions
+
+#[tokio::test]
+async fn test_get_non_existent_table() -> Result<(), Box<dyn std::error::Error>> {
+    let mut c = util::setup().await?;
+    let cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        "dummy-table-doent-exist",
+        "get",
+        "42",
+    ]);
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Cannot do operations on a non-existent table",
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_non_existent_item() -> Result<(), Box<dyn std::error::Error>> {
+    let table_name = util::create_temporary_table(vec!["pk"]).await?;
+
+    let mut c = util::setup().await?;
+    let cmd = c.args(&["--region", "local", "--table", &table_name, "get", "42"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No item found."));
+    util::cleanup(vec![&table_name]).await
+}
+
+#[tokio::test]
+async fn test_get_item() -> Result<(), Box<dyn std::error::Error>> {
+    let table_name = prepare_table_with_item().await?;
+
+    let mut c = util::setup().await?;
+    let cmd = c.args(&["--region", "local", "--table", &table_name, "get", "42"]);
+    util::assert_eq_json(
+        cmd,
+        r#"{
+          "flag": true,
+          "pk": "42"
+        }"#,
+    );
+
+    util::cleanup(vec![&table_name]).await
+}
+
+#[tokio::test]
+async fn test_get_item_output_json() -> Result<(), Box<dyn std::error::Error>> {
+    let table_name = prepare_table_with_item().await?;
+
+    let mut c = util::setup().await?;
+    let cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "get",
+        "42",
+        "-o",
+        "json",
+    ]);
+    util::assert_eq_json(
+        cmd,
+        r#"{
+          "flag": true,
+          "pk": "42"
+        }"#,
+    );
+
+    util::cleanup(vec![&table_name]).await
+}
+
+#[tokio::test]
+async fn test_get_item_output_yaml() -> Result<(), Box<dyn std::error::Error>> {
+    let table_name = prepare_table_with_item().await?;
+
+    let mut c = util::setup().await?;
+    let cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "get",
+        "42",
+        "-o",
+        "yaml",
+    ]);
+    util::assert_eq_yaml(
+        cmd,
+        r#"---
+flag: true
+pk: "42"
+"#,
+    );
+
+    util::cleanup(vec![&table_name]).await
+}
+
+#[tokio::test]
+async fn test_get_item_output_raw() -> Result<(), Box<dyn std::error::Error>> {
+    let table_name = prepare_table_with_item().await?;
+
+    let mut c = util::setup().await?;
+    let cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "get",
+        "42",
+        "-o",
+        "raw",
+    ]);
+    util::assert_eq_json(
+        cmd,
+        r#"{
+          "flag": {
+            "BOOL": true
+          },
+          "pk": {
+            "S": "42"
+          }
+        }"#,
+    );
+
+    util::cleanup(vec![&table_name]).await
+}
+
+async fn prepare_table_with_item() -> Result<String, Box<dyn std::error::Error>> {
+    let table_name = util::create_temporary_table(vec!["pk"]).await?;
+
+    let mut c = util::setup().await?;
+    c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "put",
+        "42",
+        "-i",
+        "{\"flag\": true}",
+    ])
+    .assert()
+    .success();
+
+    Ok(table_name)
+}

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -31,6 +31,8 @@ async fn test_get_non_existent_table() -> Result<(), Box<dyn std::error::Error>>
         "42",
     ]);
     cmd.assert().failure().stderr(predicate::str::contains(
+        // The error message is different between DynamoDB local and real service.
+        // It should be "Requested resource not found: Table: table not found" actually.
         "Cannot do operations on a non-existent table",
     ));
     Ok(())

--- a/tests/resources/test_batch_write.json
+++ b/tests/resources/test_batch_write.json
@@ -1,0 +1,36 @@
+{
+    "__TABLE_NAME__": [
+        {
+            "PutRequest": {
+                "Item": {
+                    "pk": { "S": "ichi" },
+                    "ISBN": { "S": "111-1111111111" },
+                    "Price": { "N": "2" },
+                    "Dimensions": { "SS": ["Giraffe", "Hippo" ,"Zebra"] },
+                    "PageCount": { "NS": ["42.2", "-19", "7.5", "3.14"] },
+                    "InPublication": { "BOOL": false },
+                    "Nothing": { "NULL": true },
+                    "Authors": {
+                        "L": [
+                            { "S": "Author1" },
+                            { "S": "Author2" },
+                            { "N": "42" }
+                        ]
+                    },
+                    "Details": {
+                        "M": {
+                            "Name": { "S": "Joe" },
+                            "Age":  { "N": "35" },
+                            "Misc": {
+                                "M": {
+                                    "hope": { "BOOL": true },
+                                    "dream": { "L": [ { "N": "35" }, { "NULL": true } ] }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/scan.rs
+++ b/tests/scan.rs
@@ -37,42 +37,32 @@ async fn test_scan_non_existent_table() -> Result<(), Box<dyn std::error::Error>
 
 #[tokio::test]
 async fn test_scan_blank_table() -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = "table--test_scan_blank_table";
+    let table_name = util::create_temporary_table(vec!["pk"]).await?;
 
     let mut c = util::setup().await?;
-    c.args(&[
-        "--region", "local", "admin", "create", "table", table_name, "--keys", "pk",
-    ])
-    .output()?;
-    let mut c = util::setup().await?;
-    let scan_cmd = c.args(&["--region", "local", "--table", table_name, "scan"]);
+    let scan_cmd = c.args(&["--region", "local", "--table", &table_name, "scan"]);
     scan_cmd
         .assert()
         .success()
         .stdout(predicate::str::contains("No item to show"));
 
-    util::cleanup(vec![table_name]).await
+    util::cleanup(vec![&table_name]).await
 }
 
 #[tokio::test]
 async fn test_simple_scan() -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = "table--test_simple_scan";
+    let table_name = util::create_temporary_table(vec!["pk"]).await?;
 
     let mut c = util::setup().await?;
-    c.args(&[
-        "--region", "local", "admin", "create", "table", table_name, "--keys", "pk",
-    ])
-    .output()?;
-    let mut c = util::setup().await?;
-    c.args(&["--region", "local", "--table", table_name, "put", "abc"])
+    c.args(&["--region", "local", "--table", &table_name, "put", "abc"])
         .output()?;
 
     let mut c = util::setup().await?;
-    let scan_cmd = c.args(&["--region", "local", "--table", table_name, "scan"]);
+    let scan_cmd = c.args(&["--region", "local", "--table", &table_name, "scan"]);
     scan_cmd
         .assert()
         .success()
         .stdout(predicate::str::contains("pk  attributes\nabc"));
 
-    util::cleanup(vec![table_name]).await
+    util::cleanup(vec![&table_name]).await
 }

--- a/tests/scan.rs
+++ b/tests/scan.rs
@@ -30,6 +30,8 @@ async fn test_scan_non_existent_table() -> Result<(), Box<dyn std::error::Error>
         "scan",
     ]);
     cmd.assert().failure().stderr(predicate::str::contains(
+        // The error message is different between DynamoDB local and real service.
+        // It should be "Requested resource not found: Table: table not found" actually.
         "Cannot do operations on a non-existent table",
     ));
     Ok(())

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -132,6 +132,7 @@ pub async fn create_temporary_table(keys: Vec<&str>) -> Result<String, Box<dyn s
         .take(16)
         .map(char::from)
         .collect();
+    println!("create temporary table: {}", table_name);
 
     let mut c = setup().await?;
     let mut args = vec![

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -187,3 +187,25 @@ pub async fn cleanup_config(dummy_dir: &str) -> io::Result<()> {
 
     remove_dir_all(dummy_dir)
 }
+
+pub fn assert_eq_json(cmd: &mut Command, expected: &str) {
+    cmd.assert().success();
+    let stdout = cmd.output().unwrap().stdout;
+    let output = String::from_utf8(stdout).unwrap();
+
+    assert_eq!(
+        output.parse::<serde_json::Value>().unwrap(),
+        expected.parse::<serde_json::Value>().unwrap(),
+    )
+}
+
+pub fn assert_eq_yaml(cmd: &mut Command, expected: &str) {
+    cmd.assert().success();
+    let stdout = cmd.output().unwrap().stdout;
+    let output = String::from_utf8(stdout).unwrap();
+
+    assert_eq!(
+        serde_yaml::from_str::<serde_yaml::Value>(&output).unwrap(),
+        serde_yaml::from_str::<serde_yaml::Value>(expected).unwrap(),
+    )
+}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

- I have added the test for `dy get` because the test is nothing
- add `create_temporary_table` function: generate random table name and output the name into stdout. So if the test is failed, we can check the name on the result

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
