### PR TITLE
feat!: Add --enable-set-inference flag to import

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -255,6 +255,7 @@ pub async fn batch_write_item(
 pub async fn convert_jsonvals_to_request_items(
     cx: &app::Context,
     items_jsonval: Vec<JsonValue>,
+    enable_set_inference: bool,
 ) -> Result<HashMap<String, Vec<WriteRequest>>, DyneinBatchError> {
     let mut results = HashMap::<String, Vec<WriteRequest>>::new();
     let mut write_requests = Vec::<WriteRequest>::new();
@@ -275,7 +276,7 @@ pub async fn convert_jsonvals_to_request_items(
         {
             item.insert(
                 attr_name.to_string(),
-                data::dispatch_jsonvalue_to_attrval(body),
+                data::dispatch_jsonvalue_to_attrval(body, enable_set_inference),
             );
         }
 
@@ -301,6 +302,7 @@ pub async fn csv_matrix_to_request_items(
     cx: &app::Context,
     matrix: &[Vec<&str>],
     headers: &[&str],
+    enable_set_inference: bool,
 ) -> Result<HashMap<String, Vec<WriteRequest>>, DyneinBatchError> {
     let total_elements_in_matrix: usize = matrix
         .iter()
@@ -333,7 +335,7 @@ pub async fn csv_matrix_to_request_items(
             );
             item.insert(
                 headers[i].to_string(),
-                data::dispatch_jsonvalue_to_attrval(&jsonval),
+                data::dispatch_jsonvalue_to_attrval(&jsonval, enable_set_inference),
             );
         }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -208,7 +208,12 @@ e.g. https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingSta
                         .expect("each item should be a valid JSON object.");
                     let item_attrval: HashMap<String, AttributeValue> = item_json
                         .iter()
-                        .map(|(k, v)| (String::from(k), data::dispatch_jsonvalue_to_attrval(v)))
+                        .map(|(k, v)| {
+                            (
+                                String::from(k),
+                                data::dispatch_jsonvalue_to_attrval(v, true),
+                            )
+                        })
                         .collect();
                     write_requests.push(WriteRequest {
                         put_request: Some(PutRequest { item: item_attrval }),

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -347,6 +347,10 @@ pub enum Sub {
         ///   csv = comma-separated values with header. Header columns are considered to be DynamoDB attributes.
         #[structopt(short, long, possible_values = &["csv", "json", "jsonl", "json-compact"])]
         format: Option<String>,
+
+        /// Enable type inference for set types. This option is provided for backward compatibility.
+        #[structopt(long)]
+        enable_set_inference: bool,
     },
 
     /// Take backup of a DynamoDB table using on-demand backup

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,9 +210,11 @@ async fn dispatch(context: &mut app::Context, subcommand: cmd::Sub) -> Result<()
             output_file,
             format,
         } => transfer::export(context.clone(), attributes, keys_only, output_file, format).await?,
-        cmd::Sub::Import { input_file, format } => {
-            transfer::import(context.clone(), input_file, format).await?
-        }
+        cmd::Sub::Import {
+            input_file,
+            format,
+            enable_set_inference,
+        } => transfer::import(context.clone(), input_file, format, enable_set_inference).await?,
         cmd::Sub::Backup { list, all_tables } => {
             if list {
                 control::list_backups(context.clone(), all_tables).await?

--- a/tests/cmd/import.md
+++ b/tests/cmd/import.md
@@ -11,13 +11,16 @@ dy admin update table your_table --mode ondemand).
 would be primary key(s).
 
 USAGE:
-    dy import [OPTIONS] --input-file <input-file>
+    dy import [FLAGS] [OPTIONS] --input-file <input-file>
 
 FLAGS:
-    -h, --help       
+        --enable-set-inference    
+            Enable type inference for set types. This option is provided for backward compatibility
+
+    -h, --help                    
             Prints help information
 
-    -V, --version    
+    -V, --version                 
             Prints version information
 
 
@@ -53,11 +56,13 @@ dy admin update table your_table --mode ondemand).
 would be primary key(s).
 
 USAGE:
-    dy import [OPTIONS] --input-file <input-file>
+    dy import [FLAGS] [OPTIONS] --input-file <input-file>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+        --enable-set-inference    Enable type inference for set types. This option is provided for backward
+                                  compatibility
+    -h, --help                    Prints help information
+    -V, --version                 Prints version information
 
 OPTIONS:
     -f, --format <format>            Data format for import items.


### PR DESCRIPTION
BREAKING CHANGE: import command no longer inferences set types without `--enable-set-inference`

*Issue #, if available:*
* #139
* Partial solution for #66

*Description of changes:*
This commit introduces the `--enable-set-inference` flag to the import command. Without this option, the import command no longer infers set types like string-set and number-set. To achieve the same behavior, you should provide the `--enable-set-inference` option. This resolves #139. Also, this can be considered the one solution for the #66 problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
