### PR TITLE
feat: add flag for developing `dy admin apply`

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -427,17 +427,20 @@ pub enum AdminSub {
         #[structopt(subcommand)]
         target_type: DeleteSub,
     },
+
+    /// [WIP] Create or update DynamoDB tables based on CloudFormation template files (.cfn.yml).
+    #[structopt(setting(structopt::clap::AppSettings::Hidden))]
+    Apply {
+        /// Try features under development
+        #[structopt(long)]
+        dev: bool,
+    },
     /*
     /// Compare the desired and current state of a DynamoDB table.
     #[structopt()]
     Plan {
         /// target table name to create/update.
         name: String,
-    },
-
-    /// Create or update DynamoDB tables based on CloudFormation template files (.cfn.yml).
-    #[structopt()]
-    Apply {
     },
 
     /// Delete all items in the target table.

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,13 @@ async fn dispatch(context: &mut app::Context, subcommand: cmd::Sub) -> Result<()
                     yes,
                 } => control::delete_table(context.clone(), table_name_to_delete, yes).await,
             },
+            cmd::AdminSub::Apply { dev } => {
+                if dev {
+                    todo!()
+                } else {
+                    println!("not yet implemented")
+                }
+            }
         },
 
         cmd::Sub::Scan {

--- a/tests/apply.rs
+++ b/tests/apply.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod util;
+
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Used for writing assertions
+
+#[tokio::test]
+async fn test_apply() -> Result<(), Box<dyn std::error::Error>> {
+    let tm = util::setup().await?;
+    let mut c = tm.command()?;
+    let cmd = c.args(&["--region", "local", "admin", "apply"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("not yet implemented"));
+    Ok(())
+}
+
+#[tokio::test]
+#[should_panic(expected = "not yet implemented")]
+async fn test_apply_with_dev() {
+    let tm = util::setup().await.unwrap();
+    let mut c = tm.command().unwrap();
+    let cmd = c.args(&["--region", "local", "admin", "apply", "--dev"]);
+    cmd.unwrap();
+}


### PR DESCRIPTION
*Issue https://github.com/awslabs/dynein/issues/155#issuecomment-1701326714

*Description of changes:*

During development, to eliminate the impact on users, ensure that apply only works when `--dev` is added.

```zsh
# just return message
$ dy admin apply
not yet implemented

# develop feature
$ dy admin apply --dev
(something happen)
```

Now, `dy admin apply --dev` causes panic.
```zsh
~/Desktop/dynein
$ ./target/release/dy admin apply
not yet implemented

~/Desktop/dynein
$ ./target/release/dy admin apply --dev
thread 'main' panicked at 'not yet implemented', src/main.rs:89:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
