### PR TITLE
feat: add binary data type support to `bwrite` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -605,6 +605,7 @@ version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "atty",
+ "base64 0.21.5",
  "brotli",
  "bytes",
  "chrono",
@@ -1704,7 +1705,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.5",
  "bytes",
  "encoding_rs",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ bytes = "1.4.0"
 itertools = "0.10.5"
 console = "0.15.7"
 brotli = "3.3.4"
+base64 = "0.21.5"
 
 [dev-dependencies]
 assert_cmd = "2.0.2" # contains helpers make executing the main binary on integration tests easier.

--- a/tests/resources/test_batch_write.json
+++ b/tests/resources/test_batch_write.json
@@ -9,6 +9,8 @@
                     "Dimensions": { "SS": ["Giraffe", "Hippo" ,"Zebra"] },
                     "PageCount": { "NS": ["42.2", "-19", "7.5", "3.14"] },
                     "InPublication": { "BOOL": false },
+                    "Binary": {"B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"},
+                    "BinarySet": {"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]},
                     "Nothing": { "NULL": true },
                     "Authors": {
                         "L": [


### PR DESCRIPTION
*Issue #, if available:*
#168

*Description of changes:*
This PR adds support for Binary data types (B, BS) to`bwrite` command. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
