### PR TITLE
test: improve setup

### DIFF
--- a/tests/admin.rs
+++ b/tests/admin.rs
@@ -21,10 +21,10 @@ use predicates::prelude::*; // Used for writing assertions
 
 #[tokio::test]
 async fn test_create_table() -> Result<(), Box<dyn std::error::Error>> {
+    let tm = util::setup().await?;
     let table_name = "table--test_create_table";
 
-    // $ dy admin create table <table_name> --keys pk
-    let mut c = util::setup().await?;
+    let mut c = tm.command()?;
     let create_cmd = c.args(&[
         "--region", "local", "admin", "create", "table", table_name, "--keys", "pk",
     ]);
@@ -37,7 +37,7 @@ async fn test_create_table() -> Result<(), Box<dyn std::error::Error>> {
         )));
 
     // $ dy admin desc <table_name>
-    let mut c = util::setup().await?;
+    let mut c = tm.command()?;
     let desc_cmd = c.args(&["--region", "local", "desc", table_name]);
     desc_cmd
         .assert()
@@ -47,7 +47,7 @@ async fn test_create_table() -> Result<(), Box<dyn std::error::Error>> {
             &table_name
         )));
 
-    util::cleanup(vec![table_name]).await
+    tm.cleanup(vec![table_name])
 }
 
 #[tokio::test]
@@ -55,9 +55,9 @@ async fn test_create_table_with_region_local_and_port_number_options(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let port = 8001;
     let table_name = "table--test_create_table_with_region_local_and_port_number_options";
+    let tm = util::setup_with_port(port).await?;
 
-    // $ dy admin create table <table_name> --keys pk
-    let mut c = util::setup_with_port(port).await?;
+    let mut c = tm.command()?;
     let create_cmd = c.args(&[
         "--region",
         "local",
@@ -79,7 +79,7 @@ async fn test_create_table_with_region_local_and_port_number_options(
         )));
 
     // $ dy admin desc <table_name>
-    let mut c = util::setup_with_port(port).await?;
+    let mut c = tm.command()?;
     let desc_cmd = c.args(&[
         "--region",
         "local",
@@ -96,5 +96,5 @@ async fn test_create_table_with_region_local_and_port_number_options(
             &table_name
         )));
 
-    util::cleanup_with_port(vec![table_name], port).await
+    tm.cleanup(vec![table_name])
 }

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -21,7 +21,9 @@ use predicates::prelude::*; // Used for writing assertions
 
 #[tokio::test]
 async fn test_bootstrap() -> Result<(), Box<dyn std::error::Error>> {
-    let mut c = util::setup().await?;
+    let tm = util::setup().await?;
+
+    let mut c = tm.command()?;
     let cmd = c.args(&["--region", "local", "bootstrap"]);
     cmd.assert().success().stdout(predicate::str::contains(
         "Now all tables have sample data. Try following commands to play with dynein. Enjoy!",
@@ -104,24 +106,25 @@ async fn test_bootstrap() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for (args, expected_json) in test_cases {
-        let mut c = util::setup().await?;
-
+        let mut c = tm.command()?;
         let cmd = c.args(&args);
         util::assert_eq_json(cmd, expected_json);
     }
 
-    util::cleanup(vec!["Forum", "ProductCatalog", "Reply", "Thread"]).await
+    tm.cleanup(vec!["Forum", "ProductCatalog", "Reply", "Thread"])
 }
 
 #[tokio::test]
 async fn test_bootstrap_movie() -> Result<(), Box<dyn std::error::Error>> {
-    let mut c = util::setup().await?;
+    let tm = util::setup().await?;
+
+    let mut c = tm.command()?;
     let cmd = c.args(&["--region", "local", "bootstrap", "--sample", "movie"]);
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("All tables are in ACTIVE."));
 
-    let mut c = util::setup().await?;
+    let mut c = tm.command()?;
     let cmd = c.args(&[
         "--region",
         "local",
@@ -163,5 +166,5 @@ async fn test_bootstrap_movie() -> Result<(), Box<dyn std::error::Error>> {
       "#,
     );
 
-    util::cleanup(vec!["Movie"]).await
+    tm.cleanup(vec!["Movie"])
 }

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -19,7 +19,9 @@ use predicates::prelude::*; // Used for writing assertions
 
 #[tokio::test]
 async fn test_list_table_with_no_table() -> Result<(), Box<dyn std::error::Error>> {
-    let mut c = util::setup().await?;
+    let tm = util::setup_with_lock().await?;
+
+    let mut c = tm.command()?;
     let cmd = c.args(&["--region", "local", "list"]);
     cmd.assert().success().stdout(
         predicate::str::is_match(
@@ -34,15 +36,16 @@ async fn test_list_table_with_no_table() -> Result<(), Box<dyn std::error::Error
 
 #[tokio::test]
 async fn test_list_table_with_multiple_tables() -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = util::create_temporary_table("pk", None).await?;
-    let table_name2 = util::create_temporary_table("pk", None).await?;
+    let mut tm = util::setup().await?;
+    let table_name = tm.create_temporary_table("pk", None).await?;
+    let table_name2 = tm.create_temporary_table("pk", None).await?;
 
-    let mut c = util::setup().await?;
+    let mut c = tm.command()?;
     let cmd = c.args(&["--region", "local", "list"]);
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("DynamoDB tables in region: local"))
         .stdout(predicate::str::contains(&table_name))
         .stdout(predicate::str::contains(&table_name2));
-    util::cleanup(vec![&table_name, &table_name2]).await
+    Ok(())
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -21,9 +21,19 @@ use predicates::prelude::*; // Used for writing assertions
 
 #[tokio::test]
 async fn test_simple_query() -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = prepare_pk_sk_table().await?;
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,N"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("2"), None),
+            ],
+        )
+        .await?;
 
-    let mut c = util::setup().await?;
+    let mut c = tm.command()?;
     let query_cmd = c.args(&["--region", "local", "--table", &table_name, "query", "abc"]);
     query_cmd
         .assert()
@@ -32,14 +42,24 @@ async fn test_simple_query() -> Result<(), Box<dyn std::error::Error>> {
             "pk   sk  attributes\nabc  1\nabc  2",
         ));
 
-    util::cleanup(vec![&table_name]).await
+    Ok(())
 }
 
 #[tokio::test]
 async fn test_simple_desc_query() -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = prepare_pk_sk_table().await?;
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,N"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("2"), None),
+            ],
+        )
+        .await?;
 
-    let mut c = util::setup().await?;
+    let mut c = tm.command()?;
     let query_cmd = c.args(&[
         "--region",
         "local",
@@ -56,14 +76,24 @@ async fn test_simple_desc_query() -> Result<(), Box<dyn std::error::Error>> {
             "pk   sk  attributes\nabc  2\nabc  1",
         ));
 
-    util::cleanup(vec![&table_name]).await
+    Ok(())
 }
 
 #[tokio::test]
 async fn test_query_limit() -> Result<(), Box<dyn std::error::Error>> {
-    let table_name = prepare_pk_sk_table().await?;
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,N"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("2"), None),
+            ],
+        )
+        .await?;
 
-    let mut c = util::setup().await?;
+    let mut c = tm.command()?;
     let query_cmd = c.args(&[
         "--region",
         "local",
@@ -79,33 +109,5 @@ async fn test_query_limit() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains("pk   sk  attributes\nabc  1"));
 
-    util::cleanup(vec![&table_name]).await
-}
-
-async fn prepare_pk_sk_table() -> Result<String, Box<dyn std::error::Error>> {
-    let table_name = util::create_temporary_table("pk,S", Some("sk,N")).await?;
-
-    let mut c = util::setup().await?;
-    c.args(&[
-        "--region",
-        "local",
-        "--table",
-        &table_name,
-        "put",
-        "abc",
-        "1",
-    ])
-    .output()?;
-    let mut c = util::setup().await?;
-    c.args(&[
-        "--region",
-        "local",
-        "--table",
-        &table_name,
-        "put",
-        "abc",
-        "2",
-    ])
-    .output()?;
-    Ok(table_name)
+    Ok(())
 }

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -26,9 +26,10 @@ async fn test_shell_mode() -> Result<(), Box<dyn std::error::Error>> {
     use std::io::{Seek, SeekFrom};
 
     let table_name = "table--test_shell_mode";
+    let tm = util::setup().await?;
 
     // $ dy admin create table <table_name> --keys pk
-    let mut c = util::setup().await?;
+    let mut c = tm.command()?;
     let shell_session = c.args(&["--region", "local", "--shell"]);
     let mut tmpfile = Builder::new().tempfile()?.into_file();
     writeln!(tmpfile, "admin create table {} --keys pk", table_name)?;
@@ -44,5 +45,5 @@ async fn test_shell_mode() -> Result<(), Box<dyn std::error::Error>> {
             &table_name
         )));
 
-    util::cleanup(vec![table_name]).await
+    tm.cleanup(vec![table_name])
 }


### PR DESCRIPTION
*Issue #, if available:*

#157 #169 

*Description of changes:*

- `TestManager.command` return `Command::cargo_bin` as wrapper.
- Table which is created by `TestManager.create_temporary_table` is deleted automatically.
- add `util::setup_with_lock` to ensure that a test is the only one at a time.
  - test_admin_desc_all_tables: when the flag `--all-tables` is specified, dynein call ListTable and DescribeTable. It will cause not found error because the table is deleted by other test.
  - test_desc_all_tables: same situation with test_admin_desc_all_tables
  - test_list_table_with_no_table: if other test create table, this test is failed because the test check `No table in this region.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
