### PR TITLE
fix: use temp file to write config

### DIFF
--- a/tests/auxiliary.rs
+++ b/tests/auxiliary.rs
@@ -20,7 +20,6 @@ use assert_cmd::prelude::*; // Add methods on commands
 use predicates::prelude::*; // Used for writing assertions
 use std::process::Command; // Run programs
                            // use assert_cmd::cmd::Command; // Run programs - it seems to be equal to "use assert_cmd::prelude::* + use std::process::Command"
-use std::path::Path;
 
 #[tokio::test]
 async fn test_help() -> Result<(), Box<dyn std::error::Error>> {
@@ -41,23 +40,17 @@ async fn test_custom_config_location() -> Result<(), Box<dyn std::error::Error>>
 
     // cleanup config folder in case it was already there
     util::cleanup_config(dummy_dir).await.ok();
-    check_file_exist(&config_dir, false);
+    util::check_dynein_files_existence(&config_dir, false);
 
     // run any dy command to generate default config
     let mut c = tm.command()?;
     c.env("DYNEIN_CONFIG_DIR", dummy_dir).assert();
 
     // check config folder created at our desired location
-    check_file_exist(&config_dir, true);
+    util::check_dynein_files_existence(&config_dir, true);
 
     // cleanup config folder
     util::cleanup_config(dummy_dir).await.ok();
 
     Ok(())
-}
-
-fn check_file_exist(dir: &str, exist: bool) {
-    assert_eq!(Path::new(&dir).exists(), exist);
-    assert_eq!(Path::new(&format!("{}/config.yml", dir)).exists(), exist);
-    assert_eq!(Path::new(&format!("{}/cache.yml", dir)).exists(), exist);
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -25,6 +25,7 @@ use regex::bytes::Regex;
 use rusoto_core::Region;
 use rusoto_dynamodb::{DynamoDb, DynamoDbClient};
 use std::io::{self, Write}; // Used when check results by printing to stdout
+use std::path::Path;
 use std::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 use tokio::time::sleep;
@@ -298,6 +299,12 @@ impl TemporaryItem {
 
         result
     }
+}
+
+pub fn check_dynein_files_existence(dir: &str, exist: bool) {
+    assert_eq!(Path::new(&dir).exists(), exist);
+    assert_eq!(Path::new(&format!("{}/config.yml", dir)).exists(), exist);
+    assert_eq!(Path::new(&format!("{}/cache.yml", dir)).exists(), exist);
 }
 
 pub async fn cleanup_config(dummy_dir: &str) -> io::Result<()> {


### PR DESCRIPTION
*Issue #, if available:*

#172 

*Description of changes:*

We use temp file to generate default config. Because while fs::write is writing the contents to default config path, serde_yaml::from_str return EndOfStream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
