### PR TITLE
chore(bootstrap): print region where table already exists

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -322,8 +322,9 @@ async fn prepare_table(cx: &app::Context, table_name: &str, keys: &[&str]) {
         }
         Err(e) => match e {
             RusotoError::Service(CreateTableError::ResourceInUse(_)) => println!(
-                "[skip] Table '{}' already exists, skipping to create new one.",
-                &table_name
+                "[skip] Table '{}' already exists in {} region, skipping to create new one.",
+                &table_name,
+                &cx.effective_region().name()
             ),
             _ => {
                 debug!("CreateTable API call got an error -- {:#?}", e);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Print region where table already exists for making easier to debug why skip to create new table

ref:
https://github.com/awslabs/dynein/blob/d546a36899bd7f765cb57b7c3c2b7139458b635f/src/bootstrap.rs#L315-L322

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
