### PR TITLE
feat!: improve query to support dynein format

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,8 +543,8 @@ year  title                  attributes
 1960  The Time Machine       {"info":{"actors":["Alan Young","Rod Taylor","Yvet...
 ```
 
-Other examples for the `--sort-key` option of `dy query` are: `--sort-key "= 42"`, `--sort-key "> 42"`, or `--sort-key "between 10 and 42"`. For more details please visit [a public document "Working with Queries"](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html) and [DynamoDB Query API reference](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html).
-
+Other examples for the `--sort-key` option of `dy query` are: `--sort-key "= 42"`, `--sort-key "> 42"`, or `--sort-key "between 10 and 42"`.
+You can find a more detailed explanation in the dedicated [`dy query` command document](./docs/query.md).
 
 ### Write
 

--- a/docs/query.md
+++ b/docs/query.md
@@ -1,0 +1,136 @@
+# `dy query` command
+In dynein, you can use `dy query` command to retrieve items that match the specified condition.
+
+You can specify the following conditions:
+
+* Partition key
+* Sort key condition
+
+The partition key is a required argument and only supports exact equal matches.
+On the other hand, the sort key condition is the optional argument.
+When you do not specify the sort key condition, DynamoDB returns all items whose partition key matches the specified value.
+
+For example, you can use the following command to retrieve the items whose partition key is `0001`.
+
+```bash
+dy admin create table query-format --keys pk,S sk,S
+dy use query-format
+dy put 0001 01
+dy put 0001 02
+dy put 0001 11
+dy put 0001 12
+dy query 0001
+```
+
+Please note that partition and sort keys are defined as string type (S).
+The output of `dy query 0001` must be the following:
+
+```log
+pk    sk  attributes
+0001  01
+0001  02
+0001  11
+0001  12
+```
+
+If you need the items whose sort key starts with `0`, you can use the following command.
+
+```bash
+dy query 0001 -s 'begins_with "0"'
+```
+
+The output is as follows:
+
+```log
+pk    sk  attributes
+0001  01
+0001  02
+```
+
+As mentioned earlier, you must provide the partition key for the query command.
+If you find another primary key is beneficial for your access patterns, you can use [secondary indexes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/SecondaryIndexes.html).
+
+For more details regarding the query operation, please visit AWS documents ["Working with Queries"](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html) and [DynamoDB Query API reference](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html).
+
+### Supported comparison operators
+In sort key condition, you can use the following operations:
+
+
+| Comparison operators               | Condition meanings                                                       |
+|------------------------------------|--------------------------------------------------------------------------|
+| `= A` or `== A`                    | a value of the sort key is equal to `A`                                  |
+| `< A`                              | a value of the sort key is less than `A`                                 |
+| `<= A`                             | a value of the sort key is less than or equal to `A`                     |
+| `> A`                              | a value of the sort key is greater than `A`                              |
+| `>= A`                             | a value of the sort key is greater than or equal to`A`                   |
+| `BETWEEN A AND B` or `BETWEEN A B` | a value of the sort key is between `A` and `B` (inclusive at both sides) |
+| `BEGINS_WITH A`                    | a value of the sort key has a prefix A                                   |
+
+The keywords `BETWEEN`, `AND`, and `BEGINS_WITH` are case-insensitive.
+
+## Sort key format
+Dynein provides two types of sort key formats: strict and non-strict.
+By default, dynein tries to parse both input formats.
+The first try is the strict format, and the second is the non-strict format.
+Therefore, if your input matches the strict format, it is not parsed as the non-strict format.
+
+You can use the `--strict` option to enforce the use of the strict format.
+Dynein raises an error if you provide a non-strict input.
+On the other hand, when the `--no-strict` option is provided, dynein checks the same as the default, even if you specify the strict mode in your config.
+
+### Strict format
+In strict format, you must specify a correct value in [dynein format](./format.md) for the right-hand value of comparison operators.
+Providing the correct type is your responsibility.
+For example, you can use the following command to retrieve items from the table whose sort key is string type.
+
+```bash
+dy query --strict 0001 -s '< "1"'
+```
+
+If you do not specify the correct type, dynein raises an error.
+For example, you undergo an error in the following command with the same table.
+
+```bash
+dy query --strict 0001 -s '<= 1'
+```
+
+Raw `1` means a value of the number type, which does not align with the table definition, which expects the string type.
+Therefore, dynein does not accept this input.
+
+### Non-strict format
+In the non-strict format, your right-hand value does not need to align with the table definition.
+Dynein tries to reach your intention as much as possible.
+This means that parsing for the non-strict format may change to improve user experience in the future, and **it may not be treated as breaking changes**.
+
+For example, the following command succeeds against the table whose sort key is string type.
+
+```bash
+dy query --non-strict 0001 -s '<= 1'
+```
+
+The dynein understands the above expression the same as follows:
+
+```bash
+dy query --strict 0001 -s '<= "1"'
+```
+
+Also, when you want to specify the equal operator, you can specify its value directly.
+
+```bash
+dy query --non-strict 0001 -s '01'
+```
+
+It is semantically equivalent to the following command:
+
+```bash
+dy query --strict 0001 -s '= "01"'
+```
+
+### Configuration
+You can change the default behavior whether dynein accepts a non-strict format.
+If you want to enforce the strict format, you can utilize the `strict_mode` option in `~/.dynein/config.yml`.
+
+```yaml
+query:
+  strict_mode: true
+```

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -200,6 +200,22 @@ pub enum Sub {
         #[structopt(short, long)]
         descending: bool,
 
+        /// Specify the strict mode for parsing query conditions.
+        /// By default, the non-strict mode is used unless specified on the config file.
+        /// You cannot combine with --non-strict option.
+        ///
+        /// In strict mode, you will experience an error if the provided value does not match the table schema.
+        #[structopt(long, conflicts_with = "non_strict")]
+        strict: bool,
+
+        /// Specify the non-strict mode for parsing query conditions.
+        /// By default, the non-strict mode is used unless specified on the config file.
+        /// You cannot combine with --strict option.
+        ///
+        /// In non-strict mode, dynein tries to infer the intention of the provided expression as much as possible.
+        #[structopt(long, conflicts_with = "strict")]
+        non_strict: bool,
+
         /// Switch output format.
         #[structopt(short, long, possible_values = &["table", "json", "raw"])]
         output: Option<String>,

--- a/src/expression.pest
+++ b/src/expression.pest
@@ -23,6 +23,49 @@ WHITESPACE = _{ " " | "\t" | "\n" | "\r" }
 // See: https://github.com/pest-parser/pest/issues/304
 eoi = _{ !ANY }
 
+// `sort_key` rule is used to parse a condition of a sort key in a query command.
+// Supported operators and a function are listed on the following docs.
+// https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.KeyConditionExpressions.html
+sort_key = { SOI ~ (sort_eq | sort_le | sort_lt | sort_ge | sort_gt | sort_between | sort_begins_with) ~ eoi }
+sort_eq = { "==" ~ sort_key_literal | "=" ~ sort_key_literal }
+sort_le = { "<=" ~ sort_key_literal }
+sort_lt = { "<" ~ sort_key_literal }
+sort_ge = { ">=" ~ sort_key_literal }
+sort_gt = { ">" ~ sort_key_literal }
+sort_between = {
+  ^"between" ~ sort_key_literal ~ ^"and" ~ sort_key_literal |
+  ^"between" ~ sort_key_literal ~ sort_key_literal
+}
+sort_begins_with = { ^"begins_with" ~ sort_key_literal }
+
+// `sort_key_str` rule matches a sort key of string types in non-strict mode
+sort_key_str = { SOI ~ (sort_eq_str | sort_le_str | sort_lt_str | sort_ge_str | sort_gt_str | sort_between_str | sort_begins_with_str | bare_str) ~ eoi }
+sort_eq_str = { "==" ~ bare_str | "=" ~ bare_str }
+sort_le_str = { "<=" ~ bare_str }
+sort_lt_str = { "<" ~ bare_str }
+sort_ge_str = { ">=" ~ bare_str }
+sort_gt_str = { ">" ~ bare_str }
+sort_between_str = {
+  ^"between" ~ bare_str ~ ^"and" ~ bare_str |
+  ^"between" ~ bare_str ~ bare_str
+}
+sort_begins_with_str = { ^"begins_with" ~ bare_str }
+bare_str = @{ bare_str_charset_first ~ bare_str_charset* }
+bare_str_charset_first = _{ !("\0" | "\r" | "\n" | "\t" | "\\" | "\"" | "'" | " " | "<" | ">" | "=") ~ ANY}
+bare_str_charset = _{ !("\0" | "\r" | "\n" | "\t" | "\\" | "\"" | "'" | " ") ~ ANY }
+
+// `sort_key_num` rule matches a sort key of number types in non-strict mode
+sort_key_number = { SOI ~ (sort_eq_num | sort_le_num | sort_lt_num | sort_ge_num | sort_gt_num | sort_between_num | number_literal) ~ eoi }
+sort_eq_num = { "=" ~ number_literal | "==" ~ number_literal }
+sort_le_num = { "<=" ~ number_literal }
+sort_lt_num = { "<" ~ number_literal }
+sort_ge_num = { ">=" ~ number_literal }
+sort_gt_num = { ">" ~ number_literal }
+sort_between_num = {
+  ^"between" ~ number_literal ~ ^"and" ~ number_literal |
+  ^"between" ~ number_literal ~ number_literal
+}
+
 // You can find the grammar for actions of UpdateItem in the following link.
 // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html
 set_action = { SOI ~ path ~ "=" ~ value ~ ("," ~ path ~ "=" ~ value)* ~ eoi }
@@ -69,6 +112,9 @@ if_not_exists_function = { ^"if_not_exists" ~ "(" ~ path ~ "," ~ value ~ ")" }
 literal = _{
   boolean_literal | null_literal | b_literal | list_literal | map_literal  | string_literal | number_literal |
   set_literal
+}
+sort_key_literal = _{
+    b_literal | string_literal | number_literal
 }
 
 // Boolean literals

--- a/tests/cmd/query.md
+++ b/tests/cmd/query.md
@@ -9,38 +9,65 @@ USAGE:
     dy query [FLAGS] [OPTIONS] <pval>
 
 FLAGS:
-        --consistent-read    Strong consistent read - to make sure retrieve the most up-to-date data. By default
-                             (false), eventual consistent reads would occur.
-                             https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html
-    -d, --descending         Results of query are always sorted by the sort key value. By default, the sort order is
-                             ascending. Specify --descending to traverse descending order
-    -h, --help               Prints help information
-        --keys-only          Show only Primary Key(s)
-    -V, --version            Prints version information
+        --consistent-read    
+            Strong consistent read - to make sure retrieve the most up-to-date data. By default (false), eventual
+            consistent reads would occur.
+            https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html
+    -d, --descending         
+            Results of query are always sorted by the sort key value. By default, the sort order is ascending. Specify
+            --descending to traverse descending order
+    -h, --help               
+            Prints help information
+
+        --keys-only          
+            Show only Primary Key(s)
+
+        --non-strict         
+            Specify the non-strict mode for parsing query conditions. By default, the non-strict mode is used unless
+            specified on the config file. You cannot combine with --strict option.
+            
+            In non-strict mode, dynein tries to infer the intention of the provided expression as much as possible.
+        --strict             
+            Specify the strict mode for parsing query conditions. By default, the non-strict mode is used unless
+            specified on the config file. You cannot combine with --non-strict option.
+            
+            In strict mode, you will experience an error if the provided value does not match the table schema.
+    -V, --version            
+            Prints version information
+
 
 OPTIONS:
-    -a, --attributes <attributes>           Attributes to show, separated by commas, which is mapped to
-                                            ProjectionExpression (e.g. --attributes name,address,age). Note that primary
-                                            key(s) are always included in results regardless of what you've passed to
-                                            --attributes
-    -i, --index <index>                     Read data from index instead of base table
-    -l, --limit <limit>                     Limit the number of items to return. By default, the number of items is
-                                            determined by DynamoDB
-    -o, --output <output>                   Switch output format [possible values: table, json, raw]
-    -p, --port <port>                       Specify the port number. This option has an effect only when `--region
-                                            local` is used
-    -r, --region <region>                   The region to use (e.g. --region us-east-1). When using DynamodB Local, use
-                                            `--region local`. You can use --region option in both top-level and
-                                            subcommand-level
-    -s, --sort-key <sort-key-expression>    Additional Sort Key condition which will be converted to
-                                            KeyConditionExpression. Valid syntax: ['= 12', '> 12', '>= 12', '< 12', '<=
-                                            12', 'between 10 and 99', 'begins_with myVal"]
-    -t, --table <table>                     Target table of the operation. You can use --table option in both top-level
-                                            and subcommand-level. You can store table schema locally by executing `$ dy
-                                            use`, after that you need not to specify --table on every command
+    -a, --attributes <attributes>           
+            Attributes to show, separated by commas, which is mapped to ProjectionExpression (e.g. --attributes
+            name,address,age). Note that primary key(s) are always included in results regardless of what you've passed
+            to --attributes
+    -i, --index <index>                     
+            Read data from index instead of base table
+
+    -l, --limit <limit>                     
+            Limit the number of items to return. By default, the number of items is determined by DynamoDB
+
+    -o, --output <output>                   
+            Switch output format [possible values: table, json, raw]
+
+    -p, --port <port>                       
+            Specify the port number. This option has an effect only when `--region local` is used
+
+    -r, --region <region>                   
+            The region to use (e.g. --region us-east-1). When using DynamodB Local, use `--region local`. You can use
+            --region option in both top-level and subcommand-level
+    -s, --sort-key <sort-key-expression>    
+            Additional Sort Key condition which will be converted to KeyConditionExpression. Valid syntax: ['= 12', '>
+            12', '>= 12', '< 12', '<= 12', 'between 10 and 99', 'begins_with myVal"]
+    -t, --table <table>                     
+            Target table of the operation. You can use --table option in both top-level and subcommand-level. You can
+            store table schema locally by executing `$ dy use`, after that you need not to specify --table on every
+            command
 
 ARGS:
-    <pval>    Target Partition Key
+    <pval>    
+            Target Partition Key
+
 
 $ dy help query
 dy-query 0.2.1
@@ -57,6 +84,10 @@ FLAGS:
                              ascending. Specify --descending to traverse descending order
     -h, --help               Prints help information
         --keys-only          Show only Primary Key(s)
+        --non-strict         Specify the non-strict mode for parsing query conditions. By default, the non-strict mode
+                             is used unless specified on the config file. You cannot combine with --strict option
+        --strict             Specify the strict mode for parsing query conditions. By default, the non-strict mode is
+                             used unless specified on the config file. You cannot combine with --non-strict option
     -V, --version            Prints version information
 
 OPTIONS:

--- a/tests/cmd_windows/query.md
+++ b/tests/cmd_windows/query.md
@@ -9,38 +9,65 @@ USAGE:
     dy[EXE] query [FLAGS] [OPTIONS] <pval>
 
 FLAGS:
-        --consistent-read    Strong consistent read - to make sure retrieve the most up-to-date data. By default
-                             (false), eventual consistent reads would occur.
-                             https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html
-    -d, --descending         Results of query are always sorted by the sort key value. By default, the sort order is
-                             ascending. Specify --descending to traverse descending order
-    -h, --help               Prints help information
-        --keys-only          Show only Primary Key(s)
-    -V, --version            Prints version information
+        --consistent-read    
+            Strong consistent read - to make sure retrieve the most up-to-date data. By default (false), eventual
+            consistent reads would occur.
+            https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html
+    -d, --descending         
+            Results of query are always sorted by the sort key value. By default, the sort order is ascending. Specify
+            --descending to traverse descending order
+    -h, --help               
+            Prints help information
+
+        --keys-only          
+            Show only Primary Key(s)
+
+        --non-strict         
+            Specify the non-strict mode for parsing query conditions. By default, the non-strict mode is used unless
+            specified on the config file. You cannot combine with --strict option.
+            
+            In non-strict mode, dynein tries to infer the intention of the provided expression as much as possible.
+        --strict             
+            Specify the strict mode for parsing query conditions. By default, the non-strict mode is used unless
+            specified on the config file. You cannot combine with --non-strict option.
+            
+            In strict mode, you will experience an error if the provided value does not match the table schema.
+    -V, --version            
+            Prints version information
+
 
 OPTIONS:
-    -a, --attributes <attributes>           Attributes to show, separated by commas, which is mapped to
-                                            ProjectionExpression (e.g. --attributes name,address,age). Note that primary
-                                            key(s) are always included in results regardless of what you've passed to
-                                            --attributes
-    -i, --index <index>                     Read data from index instead of base table
-    -l, --limit <limit>                     Limit the number of items to return. By default, the number of items is
-                                            determined by DynamoDB
-    -o, --output <output>                   Switch output format [possible values: table, json, raw]
-    -p, --port <port>                       Specify the port number. This option has an effect only when `--region
-                                            local` is used
-    -r, --region <region>                   The region to use (e.g. --region us-east-1). When using DynamodB Local, use
-                                            `--region local`. You can use --region option in both top-level and
-                                            subcommand-level
-    -s, --sort-key <sort-key-expression>    Additional Sort Key condition which will be converted to
-                                            KeyConditionExpression. Valid syntax: ['= 12', '> 12', '>= 12', '< 12', '<=
-                                            12', 'between 10 and 99', 'begins_with myVal"]
-    -t, --table <table>                     Target table of the operation. You can use --table option in both top-level
-                                            and subcommand-level. You can store table schema locally by executing `$ dy
-                                            use`, after that you need not to specify --table on every command
+    -a, --attributes <attributes>           
+            Attributes to show, separated by commas, which is mapped to ProjectionExpression (e.g. --attributes
+            name,address,age). Note that primary key(s) are always included in results regardless of what you've passed
+            to --attributes
+    -i, --index <index>                     
+            Read data from index instead of base table
+
+    -l, --limit <limit>                     
+            Limit the number of items to return. By default, the number of items is determined by DynamoDB
+
+    -o, --output <output>                   
+            Switch output format [possible values: table, json, raw]
+
+    -p, --port <port>                       
+            Specify the port number. This option has an effect only when `--region local` is used
+
+    -r, --region <region>                   
+            The region to use (e.g. --region us-east-1). When using DynamodB Local, use `--region local`. You can use
+            --region option in both top-level and subcommand-level
+    -s, --sort-key <sort-key-expression>    
+            Additional Sort Key condition which will be converted to KeyConditionExpression. Valid syntax: ['= 12', '>
+            12', '>= 12', '< 12', '<= 12', 'between 10 and 99', 'begins_with myVal"]
+    -t, --table <table>                     
+            Target table of the operation. You can use --table option in both top-level and subcommand-level. You can
+            store table schema locally by executing `$ dy use`, after that you need not to specify --table on every
+            command
 
 ARGS:
-    <pval>    Target Partition Key
+    <pval>    
+            Target Partition Key
+
 
 $ dy help query
 dy[EXE]-query 0.2.1
@@ -57,6 +84,10 @@ FLAGS:
                              ascending. Specify --descending to traverse descending order
     -h, --help               Prints help information
         --keys-only          Show only Primary Key(s)
+        --non-strict         Specify the non-strict mode for parsing query conditions. By default, the non-strict mode
+                             is used unless specified on the config file. You cannot combine with --strict option
+        --strict             Specify the strict mode for parsing query conditions. By default, the non-strict mode is
+                             used unless specified on the config file. You cannot combine with --non-strict option
     -V, --version            Prints version information
 
 OPTIONS:

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -64,6 +64,8 @@ tables: ~
 using_region: ~
 using_table: ~
 using_port: ~
+query:
+  strict_mode: false
 
 ",
     );
@@ -100,6 +102,8 @@ tables:
 using_region: local
 using_table: {table_name}
 using_port: 8000
+query:
+  strict_mode: false
 
 "
     ));

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -111,3 +111,324 @@ async fn test_query_limit() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_query_with_sort_key() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,N"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("2"), None),
+                util::TemporaryItem::new("abc", Some("3"), None),
+            ],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    let query_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "query",
+        "abc",
+        "-s",
+        "2",
+    ]);
+    query_cmd.assert().success().stdout(
+        predicate::str::is_match("pk +sk +attributes\n")
+            .unwrap()
+            .and(predicate::str::is_match("abc +1\n").unwrap().not())
+            .and(predicate::str::is_match("abc +2\n").unwrap())
+            .and(predicate::str::is_match("abc +3\n").unwrap().not()),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_with_sort_key_order() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,N"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("2"), None),
+                util::TemporaryItem::new("abc", Some("3"), None),
+            ],
+        )
+        .await?;
+
+    for _ in 1..10 {
+        let mut c = tm.command()?;
+        let query_cmd = c.args(&[
+            "--region",
+            "local",
+            "--table",
+            &table_name,
+            "query",
+            "abc",
+            "-s",
+            "< 5",
+        ]);
+        query_cmd.assert().success().stdout(
+            predicate::str::is_match("pk +sk +attributes\nabc +1\nabc +2\nabc +3\n").unwrap(),
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_with_sort_key_le() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,N"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("2"), None),
+                util::TemporaryItem::new("abc", Some("3"), None),
+            ],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    let query_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "query",
+        "abc",
+        "-s",
+        "<=2",
+    ]);
+    query_cmd.assert().success().stdout(
+        predicate::str::is_match("pk +sk +attributes\n")
+            .unwrap()
+            .and(predicate::str::is_match("abc +1\n").unwrap())
+            .and(predicate::str::is_match("abc +2\n").unwrap())
+            .and(predicate::str::is_match("abc +3\n").unwrap().not()),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_using_between_string() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,S"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("11"), None),
+                util::TemporaryItem::new("abc", Some("2"), None),
+                util::TemporaryItem::new("abc", Some("21"), None),
+                util::TemporaryItem::new("abc", Some("22"), None),
+            ],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    let query_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "query",
+        "abc",
+        "-s",
+        "between 11 21",
+    ]);
+    query_cmd.assert().success().stdout(
+        predicate::str::is_match("pk +sk +attributes\n")
+            .unwrap()
+            .and(predicate::str::is_match("abc +1\n").unwrap().not())
+            .and(predicate::str::is_match("abc +11\n").unwrap())
+            .and(predicate::str::is_match("abc +2\n").unwrap())
+            .and(predicate::str::is_match("abc +21\n").unwrap())
+            .and(predicate::str::is_match("abc +22\n").unwrap().not()),
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_using_between_number() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,N"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("11"), None),
+                util::TemporaryItem::new("abc", Some("2"), None),
+                util::TemporaryItem::new("abc", Some("21"), None),
+                util::TemporaryItem::new("abc", Some("22"), None),
+            ],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    let query_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "query",
+        "abc",
+        "-s",
+        "between 11 21",
+    ]);
+    query_cmd.assert().success().stdout(
+        predicate::str::is_match("pk +sk +attributes\n")
+            .unwrap()
+            .and(predicate::str::is_match("abc +1\n").unwrap().not())
+            .and(predicate::str::is_match("abc +11\n").unwrap())
+            .and(predicate::str::is_match("abc +2\n").unwrap().not())
+            .and(predicate::str::is_match("abc +21\n").unwrap())
+            .and(predicate::str::is_match("abc +22\n").unwrap().not()),
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_using_begins_with() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,S"),
+            vec![
+                util::TemporaryItem::new("abc", Some("1"), None),
+                util::TemporaryItem::new("abc", Some("11"), None),
+                util::TemporaryItem::new("abc", Some("21"), None),
+                util::TemporaryItem::new("abc", Some("22"), None),
+            ],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    let query_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "query",
+        "abc",
+        "-s",
+        "begins_with 1",
+    ]);
+    query_cmd.assert().success().stdout(
+        predicate::str::is_match("pk +sk +attributes\n")
+            .unwrap()
+            .and(predicate::str::is_match("abc +1\n").unwrap())
+            .and(predicate::str::is_match("abc +11\n").unwrap())
+            .and(predicate::str::is_match("abc +21\n").unwrap().not())
+            .and(predicate::str::is_match("abc +22\n").unwrap().not()),
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_invalid_input() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,S"),
+            vec![util::TemporaryItem::new("abc", Some("2"), None)],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    let query_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "query",
+        "abc",
+        "-s",
+        r#"= 3*"2""#,
+    ]);
+    query_cmd
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("= expected sort_key_str"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_with_strict_mode_with_suggestion() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,S"),
+            vec![util::TemporaryItem::new("abc", Some("2"), None)],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    let query_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "query",
+        "--strict",
+        "abc",
+        "-s",
+        "=2",
+    ]);
+    query_cmd.assert().failure().stderr(
+        predicate::str::contains(
+            "Invalid type detected. Expected type is string (S), but actual type is number (N).",
+        )
+        .and(predicate::str::contains(r#"Did you intend '= "2"'?"#)),
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_query_with_strict_mode_without_suggestion() -> Result<(), Box<dyn std::error::Error>>
+{
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk,N"),
+            vec![util::TemporaryItem::new("abc", Some("8"), None)],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    let query_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "query",
+        "--strict",
+        "abc",
+        "-s",
+        r#"= "2*4""#,
+    ]);
+    query_cmd.assert().failure().stderr(
+        predicate::str::contains(
+            "Invalid type detected. Expected type is number (N), but actual type is string (S).",
+        )
+        .and(predicate::str::contains(r#"Did you intend"#).not()),
+    );
+    Ok(())
+}


### PR DESCRIPTION
*Issue #, if available:*
Implement #163

*Description of changes:*
This PR improves the parsing for the sort key condition. The current implementation cannot handle the sort key containing spaces. This PR fixes this and provides a way that is compatible with the dynein format.

Improvements contain the following features:

* Introduce two formats for --sort-key: strict format and non-strict.
* You can now query any condition DynamoDB supports using the strict format.
* The non-strict format allows the user less typing and types agnostic input.
* The non-strict format retains the same experience as much as possible.
* Add --strict and --non-strict options to change the usage of non-strict.
* Add configuration option and query.strict_mode to change the default mode.

BREAKING CHANGE: Parsing --sort-key is incompatible with the previous one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
