### PR TITLE
feat(apply): load template file

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use log::error;
+use std::path::Path;
+
+pub trait PathExistenceChecker {
+    fn path_exists(&self, path: &str) -> bool;
+}
+
+pub struct RealPathExistenceChecker;
+
+impl PathExistenceChecker for RealPathExistenceChecker {
+    fn path_exists(&self, path: &str) -> bool {
+        Path::new(path).exists()
+    }
+}
+
+fn check_template(checker: &dyn PathExistenceChecker) -> Option<&'static str> {
+    let acceptable_files = ["cfn.yaml", "cfn.yml", "cfn.json"];
+    acceptable_files
+        .iter()
+        .find(|&&file_name| checker.path_exists(file_name))
+        .copied()
+}
+
+pub fn apply(checker: &dyn PathExistenceChecker) {
+    match check_template(checker) {
+        Some(file_name) => todo!("{file_name}"),
+        None => {
+            error!("cfn.yaml or cfn.yml or cfn.json is not exist");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub struct MockPathExistenceChecker {
+        mock_file: String,
+    }
+
+    impl MockPathExistenceChecker {
+        pub fn new(mock_file: &str) -> Self {
+            Self {
+                mock_file: mock_file.to_string(),
+            }
+        }
+    }
+
+    impl PathExistenceChecker for MockPathExistenceChecker {
+        fn path_exists(&self, path: &str) -> bool {
+            path == self.mock_file
+        }
+    }
+
+    #[test]
+    fn test_check_template_with_acceptable_file() {
+        let mock_checker = MockPathExistenceChecker::new("cfn.yaml");
+        let result = check_template(&mock_checker);
+        assert_eq!(result, Some("cfn.yaml"));
+    }
+
+    #[test]
+    fn test_check_template_without_acceptable_file() {
+        let mock_checker = MockPathExistenceChecker::new("some_other_file.txt");
+        let result = check_template(&mock_checker);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    #[should_panic(expected = "not yet implemented: cfn.yaml")]
+    fn test_apply_with_acceptable_file() {
+        let mock_checker = MockPathExistenceChecker::new("cfn.yaml");
+        apply(&mock_checker)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use crate::apply::RealPathExistenceChecker;
 use crate::data::QueryParams;
 use log::debug;
 use std::error::Error;
@@ -23,6 +24,7 @@ extern crate pest;
 extern crate pest_derive;
 
 mod app;
+mod apply;
 mod batch;
 mod bootstrap;
 mod cmd;
@@ -86,7 +88,7 @@ async fn dispatch(context: &mut app::Context, subcommand: cmd::Sub) -> Result<()
             },
             cmd::AdminSub::Apply { dev } => {
                 if dev {
-                    todo!()
+                    apply::apply(&RealPathExistenceChecker)
                 } else {
                     println!("not yet implemented")
                 }

--- a/tests/apply.rs
+++ b/tests/apply.rs
@@ -31,10 +31,13 @@ async fn test_apply() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio::test]
-#[should_panic(expected = "not yet implemented")]
-async fn test_apply_with_dev() {
+async fn test_apply_with_dev() -> Result<(), Box<dyn std::error::Error>> {
     let tm = util::setup().await.unwrap();
     let mut c = tm.command().unwrap();
     let cmd = c.args(&["--region", "local", "admin", "apply", "--dev"]);
-    cmd.unwrap();
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "cfn.yaml or cfn.yml or cfn.json is not exist",
+    ));
+    assert_eq!(cmd.status().unwrap().code(), Some(1));
+    Ok(())
 }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/dynein/issues/155#issuecomment-1701345514

> ### [apply] Load template file
> * Load `cfn.yaml` or `cfn.yml` or `cfn.json` in the same hierarchy where the dy command is executed
>   
>   * It is like [main.tf](https://developer.hashicorp.com/terraform/tutorials/modules/module-create#main-tf) in Terraform
> * If not exist, exit(1)
> 
> command:
> 
> ```
> ~/path/to/foo
> $ ls
> cfn.yaml
> 
> ~/path/to/foo
> (for now, just checking existence of file)
> $ dy admin apply --dev
> ```


*Description of changes:*

- implement `apply` function and `check_template` function
- mock `Path::new(path).exists()` for testing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
