### PR TITLE
feat: implement new options into bwrite command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     services:
       dynamodb:
         # Pinned to the version not to be broken with latest
-        image: amazon/dynamodb-local:1.22.0
+        image: amazon/dynamodb-local:2.2.1
         ports:
         - 8000:8000
         - 8001:8000

--- a/README.md
+++ b/README.md
@@ -995,8 +995,48 @@ No item found.
 `dy bwrite` internally calls [BatchWriteItem API](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html) and is used for putting and deleting multiple items.
 
 You can specify the `--input` option when providing operations from a JSON file that follows the Request Syntax of BatchWriteItem API.
+
 ```bash
 $ dy bwrite --input request.json
+$ cat request.json
+{
+    "__TABLE_NAME__": [
+        {
+            "PutRequest": {
+                "Item": {
+                    "pk": { "S": "ichi" },
+                    "ISBN": { "S": "111-1111111111" },
+                    "Price": { "N": "2" },
+                    "Dimensions": { "SS": ["Giraffe", "Hippo" ,"Zebra"] },
+                    "PageCount": { "NS": ["42.2", "-19", "7.5", "3.14"] },
+                    "InPublication": { "BOOL": false },
+                    "Binary": {"B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"},
+                    "BinarySet": {"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]},
+                    "Nothing": { "NULL": true },
+                    "Authors": {
+                        "L": [
+                            { "S": "Author1" },
+                            { "S": "Author2" },
+                            { "N": "42" }
+                        ]
+                    },
+                    "Details": {
+                        "M": {
+                            "Name": { "S": "Joe" },
+                            "Age":  { "N": "35" },
+                            "Misc": {
+                                "M": {
+                                    "hope": { "BOOL": true },
+                                    "dream": { "L": [ { "N": "35" }, { "NULL": true } ] }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}
 ```
 
 You can also use `--put` or `--del` options to achieve corresponding operations.
@@ -1011,7 +1051,7 @@ pk  attributes
 2   {"this_is_set":["x","y","z"]}
 ```
 
-The --put, --del, and --input options can be used simultaneously.
+The `--put`, `--del`, and `--input` options can be used simultaneously.
 
 ```bash
 $ dy bwrite --del '{"pk": "1"}' --del '{"pk": "2"}' --put '{"pk": "3", "this_is_set": <<"a","b","c">>}'
@@ -1021,7 +1061,7 @@ pk  attributes
 ```
 
 ```bash
-$ dy bwrite --del '{"pk": "1"}' --del '{"pk": "2"}' --put '{"pk": "3", "this_is_set": <<"a","b","c">>}'  --input request.json
+$ dy bwrite --del '{"pk": "1"}' --del '{"pk": "2"}' --put '{"pk": "3", "this_is_set": <<"a","b","c">>}' --input request.json
 ```
 
 ## Working with Indexes

--- a/README.md
+++ b/README.md
@@ -991,6 +991,38 @@ $ dy get 42
 No item found.
 ```
 
+#### `dy bwrite`
+`dy bwrite` internally calls [BatchWriteItem API](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html) and is used for putting and deleting multiple items.
+
+You can specify the `--input` option when providing operations from a JSON file that follows the Request Syntax of BatchWriteItem API.
+```bash
+$ dy bwrite --input request.json
+```
+
+You can also use `--put` or `--del` options to achieve corresponding operations.
+These options take the [dynein format](./docs/format.md), a JSON-style expression.
+To put or delete items, you must provide at least a primary key to identify each item uniquely.
+
+```bash
+$ dy bwrite --put '{"pk": "1", "this_is_set": <<"i","j","k">>}' --put '{"pk": "2", "this_is_set": <<"x","y","z">>}'
+$ dy scan
+pk  attributes
+1   {"this_is_set":["i","j","k"]}
+2   {"this_is_set":["x","y","z"]}
+```
+
+The --put, --del, and --input options can be used simultaneously.
+
+```bash
+$ dy bwrite --del '{"pk": "1"}' --del '{"pk": "2"}' --put '{"pk": "3", "this_is_set": <<"a","b","c">>}'
+$ dy scan
+pk  attributes
+3   {"this_is_set":["a","b","c"]}
+```
+
+```bash
+$ dy bwrite --del '{"pk": "1"}' --del '{"pk": "2"}' --put '{"pk": "3", "this_is_set": <<"a","b","c">>}'  --input request.json
+```
 
 ## Working with Indexes
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -277,7 +277,7 @@ pub async fn batch_write_item(
         if let Some(items) = puts {
             for item in items.iter() {
                 let attrs = parser.parse_dynein_format(None, item)?;
-                validate_item_has_keys(&attrs, &ts)?;
+                validate_item_keys(&attrs, &ts)?;
                 write_requests.push(WriteRequest {
                     put_request: Some(PutRequest { item: attrs }),
                     delete_request: None,
@@ -288,7 +288,7 @@ pub async fn batch_write_item(
         if let Some(keys) = dels {
             for key in keys.iter() {
                 let attrs = parser.parse_dynein_format(None, key)?;
-                validate_item_has_keys(&attrs, &ts)?;
+                validate_item_keys(&attrs, &ts)?;
                 write_requests.push(WriteRequest {
                     put_request: None,
                     delete_request: Some(DeleteRequest { key: attrs }),
@@ -572,7 +572,7 @@ fn json_binary_val_to_bytes(v: &JsonValue) -> Bytes {
 }
 
 // Check if the item has a partition key and sort key.
-fn validate_item_has_keys(
+fn validate_item_keys(
     attrs: &HashMap<String, AttributeValue>,
     ts: &app::TableSchema,
 ) -> Result<(), DyneinBatchError> {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -271,7 +271,7 @@ https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/AppendixSampleT
         let mut content = String::new();
         decompressor.read_to_string(&mut content)?;
         // Step 4. load data into tables
-        let request_items = batch::build_batch_request_items(content.to_string())?;
+        let request_items = batch::build_batch_request_items_from_json(content.to_string())?;
         batch::batch_write_untill_processed(cx.clone(), request_items).await?;
     }
     println!(

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -265,10 +265,24 @@ pub enum Sub {
     /// https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
     #[structopt(aliases = &["batch-write-item", "batch-write", "bw"])]
     Bwrite {
+        /// The item to put in Dynein format.
+        /// Each item requires at least a primary key.
+        /// Multiple items can be specified by repeating the option.
+        /// e.g. `--put '{Dynein format}' --put '{Dynein format}' --del '{Dynein format}'`
+        #[structopt(long = "put", multiple = true)]
+        puts: Option<Vec<String>>,
+
+        /// The item to delete in Dynein format.
+        /// Each item requires at least a primary key.
+        /// Multiple items can be specified by repeating the option.
+        /// e.g. `--put '{Dynein format}' --put '{Dynein format}' --del '{Dynein format}'`
+        #[structopt(long = "del", multiple = true)]
+        dels: Option<Vec<String>>,
+
         /// Input JSON file path. This input file should be BatchWriteItem input JSON syntax. For more info:
         /// https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
         #[structopt(long, short)]
-        input: String,
+        input: Option<String>,
     },
 
     /* =================================================

--- a/src/data.rs
+++ b/src/data.rs
@@ -316,7 +316,7 @@ pub async fn put_item(cx: app::Context, pval: String, sval: Option<String>, item
         None => (),
         Some(_i) => {
             let parser = DyneinParser::new();
-            let result = parser.parse_put_content(full_item_image, &_i);
+            let result = parser.parse_dynein_format(Some(full_item_image), &_i);
             match result {
                 Ok(attrs) => {
                     full_item_image = attrs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,9 @@ async fn dispatch(context: &mut app::Context, subcommand: cmd::Sub) -> Result<()
                 data::update_item(context.clone(), pval, sval, set, remove).await;
             }
         }
-        cmd::Sub::Bwrite { input } => batch::batch_write_item(context.clone(), input).await?,
+        cmd::Sub::Bwrite { puts, dels, input } => {
+            batch::batch_write_item(context.clone(), puts, dels, input).await?
+        }
 
         cmd::Sub::List { all_regions } => {
             if all_regions {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -201,6 +201,18 @@ pub enum ParseError {
     InvalidEscapeByte(EscapeByteError),
 }
 
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            ParseError::ParsingError(ref e) => write!(f, "{}", e),
+            ParseError::UnexpectedEndOfSequence(ref e) => write!(f, "{}", e),
+            ParseError::InvalidUnicodeChar(ref e) => write!(f, "{}", e),
+            ParseError::InvalidEscapeChar(ref e) => write!(f, "{}", e),
+            ParseError::InvalidEscapeByte(ref e) => write!(f, "{}", e),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 enum AttrVal {
     N(String),
@@ -836,17 +848,20 @@ impl DyneinParser {
         }
     }
 
-    pub fn parse_put_content(
+    pub fn parse_dynein_format(
         &self,
-        initial_item: HashMap<String, AttributeValue>,
+        initial_item: Option<HashMap<String, AttributeValue>>,
         exp: &str,
     ) -> Result<HashMap<String, AttributeValue>, ParseError> {
         let result = GeneratedParser::parse(Rule::map_literal, exp);
         match result {
             Ok(mut pair) => {
                 let item = parse_literal(pair.next().unwrap())?.convert_attribute_value();
-                // put content must be map literal
-                let mut image = initial_item;
+                // content must be map literal
+                let mut image = match initial_item {
+                    Some(init_item) => init_item,
+                    None => HashMap::new(),
+                };
                 image.extend(item.m.unwrap());
                 Ok(image)
             }
@@ -1557,12 +1572,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_put_content() {
+    fn test_parse_dynein_format() {
         let parser = DyneinParser::new();
         assert_eq!(
             parser
-                .parse_put_content(
-                    HashMap::new(),
+                .parse_dynein_format(
+                    None,
                     r#"{
                            "k0": null,
                            "k1": [1, 2, 3, "str"],

--- a/tests/bwrite.rs
+++ b/tests/bwrite.rs
@@ -17,6 +17,7 @@
 pub mod util;
 
 use assert_cmd::prelude::*; // Add methods on commands
+use base64::{engine::general_purpose, Engine as _};
 use predicates::prelude::*; // Used for writing assertions
 use serde_json::Value;
 use std::collections::HashSet;
@@ -30,18 +31,12 @@ async fn test_batch_write() -> Result<(), Box<dyn std::error::Error>> {
     let mut tm = util::setup().await?;
     let table_name = tm.create_temporary_table("pk", None).await?;
 
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("tests/resources/test_batch_write.json");
-    let test_json_content = std::fs::read_to_string(path)?;
-
-    let tmpdir = Builder::new().tempdir()?; // defining stand alone variable here as tempfile::tempdir creates directory and deletes it when the destructor is run.
-    let batch_input_file_path = tmpdir.path().join("test_batch_write.json");
-    let mut f = File::create(tmpdir.path().join("test_batch_write.json"))?;
-    f.write_all(
-        test_json_content
-            .replace("__TABLE_NAME__", &table_name)
-            .as_bytes(),
-    )?;
+    let tmpdir = Builder::new().tempdir().unwrap(); // defining stand alone variable here as tempfile::tempdir creates directory and deletes it when the destructor is run.
+    let batch_input_file_path = create_test_json_file(
+        "tests/resources/test_batch_write.json",
+        &table_name,
+        &tmpdir,
+    );
 
     let mut c = tm.command()?;
     c.args(&[
@@ -51,7 +46,7 @@ async fn test_batch_write() -> Result<(), Box<dyn std::error::Error>> {
         &table_name,
         "bwrite",
         "--input",
-        batch_input_file_path.to_str().unwrap(),
+        &batch_input_file_path,
     ])
     .output()?;
 
@@ -141,4 +136,277 @@ async fn test_batch_write() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(binary_set, binary_set_expected);
 
     Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_write_put() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm.create_temporary_table("pk", None).await?;
+
+    let mut c = tm.command()?;
+    c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "bwrite",
+        "--put",
+        r#"{"pk": "11",
+        "null-field": null,
+        "list-field": [1, 2, 3, "str"],
+        "map-field": {"l0": <<1, 2>>, "l1": <<"str1", "str2">>, "l2": true},
+        "binary-field": b"\x00",
+        "binary-set-field": <<b"\x01", b"\x02">>}"#,
+    ])
+    .output()?;
+
+    let mut c = tm.command()?;
+    let get_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "get",
+        "11",
+        "-o",
+        "raw",
+    ]);
+    let output = get_cmd.output()?.stdout;
+    let data: Value = serde_json::from_str(&String::from_utf8(output)?)?;
+    assert_eq!(data["pk"]["S"], "11");
+    assert_eq!(data["null-field"]["NULL"], true);
+    assert_eq!(data["list-field"]["L"][0]["N"], "1");
+    assert_eq!(data["list-field"]["L"][1]["N"], "2");
+    assert_eq!(data["list-field"]["L"][2]["N"], "3");
+    assert_eq!(data["list-field"]["L"][3]["S"], "str");
+    assert_eq!(data["map-field"]["M"]["l0"]["NS"][0], "1");
+    assert_eq!(data["map-field"]["M"]["l0"]["NS"][1], "2");
+    assert_eq!(data["map-field"]["M"]["l1"]["SS"][0], "str1");
+    assert_eq!(data["map-field"]["M"]["l1"]["SS"][1], "str2");
+    assert_eq!(data["map-field"]["M"]["l2"]["BOOL"], true);
+    assert_eq!(
+        data["binary-field"]["B"],
+        general_purpose::STANDARD.encode(b"\x00")
+    );
+    assert_eq!(
+        data["binary-set-field"]["BS"][0],
+        general_purpose::STANDARD.encode(b"\x01")
+    );
+    assert_eq!(
+        data["binary-set-field"]["BS"][1],
+        general_purpose::STANDARD.encode(b"\x02")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_write_put_sk() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm.create_temporary_table("pk", Some("sk")).await?;
+
+    let mut c = tm.command()?;
+    c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "bwrite",
+        "--put",
+        r#"{"pk": "11", "sk": "111"}"#,
+    ])
+    .output()?;
+
+    let mut c = tm.command()?;
+    let get_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "get",
+        "11",
+        "111",
+        "-o",
+        "raw",
+    ]);
+    let output = get_cmd.output()?.stdout;
+    let data: Value = serde_json::from_str(&String::from_utf8(output)?)?;
+    assert_eq!(data["pk"]["S"], "11");
+    assert_eq!(data["sk"]["S"], "111");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_write_del() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            None,
+            vec![util::TemporaryItem::new(
+                "11",
+                None,
+                Some(r#"{"null-field": null}"#),
+            )],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "bwrite",
+        "--del",
+        r#"{"pk": "11"}"#,
+    ])
+    .output()?;
+
+    let mut c = tm.command()?;
+    let scan_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "scan",
+        "-o",
+        "raw",
+    ]);
+    scan_cmd.assert().success().stdout("[]\n");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_write_del_sk() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            Some("sk"),
+            vec![util::TemporaryItem::new(
+                "11",
+                Some("111"),
+                Some(r#"{"null-field": null}"#),
+            )],
+        )
+        .await?;
+
+    let mut c = tm.command()?;
+    c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "bwrite",
+        "--del",
+        r#"{"pk": "11", "sk": "111"}"#,
+    ])
+    .output()?;
+
+    let mut c = tm.command()?;
+    let scan_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "scan",
+        "-o",
+        "raw",
+    ]);
+    scan_cmd.assert().success().stdout("[]\n");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_write_all_options() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup().await?;
+    let table_name = tm
+        .create_temporary_table_with_items(
+            "pk",
+            None,
+            vec![util::TemporaryItem::new(
+                "11",
+                None,
+                Some(r#"{"null-field": null}"#),
+            )],
+        )
+        .await?;
+
+    let tmpdir = Builder::new().tempdir().unwrap(); // defining stand alone variable here as tempfile::tempdir creates directory and deletes it when the destructor is run.
+    let batch_input_file_path = create_test_json_file(
+        "tests/resources/test_batch_write.json",
+        &table_name,
+        &tmpdir,
+    );
+    let mut c = tm.command()?;
+    c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "bwrite",
+        "--del",
+        r#"{"pk": "11"}"#,
+        "--input",
+        &batch_input_file_path,
+        "--put",
+        r#"{"pk": "12", "null-field": null}"#,
+    ])
+    .output()?;
+
+    let mut c = tm.command()?;
+    let scan_cmd = c.args(&[
+        "--region",
+        "local",
+        "--table",
+        &table_name,
+        "scan",
+        "-o",
+        "json",
+    ]);
+    let output = scan_cmd.output()?.stdout;
+    let output_str = String::from_utf8(output)?;
+    // Check if the first item put has been deleted
+    assert_eq!(
+        false,
+        predicate::str::is_match(r#""pk": "11""#)?.eval(&output_str)
+    );
+    // Check if the json file input exists
+    assert_eq!(
+        true,
+        predicate::str::is_match(r#""pk": "ichi""#)?.eval(&output_str)
+    );
+    // Check if the second item put exists
+    assert_eq!(
+        true,
+        predicate::str::is_match(r#"pk": "12""#)?.eval(&output_str)
+    );
+
+    Ok(())
+}
+
+fn create_test_json_file(
+    json_path: &str,
+    table_name: &String,
+    tmpdir: &tempfile::TempDir,
+) -> String {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push(json_path);
+    let test_json_content = std::fs::read_to_string(&path).unwrap();
+    let file_name = path.file_name().unwrap();
+
+    let batch_input_file_path = tmpdir.path().join(file_name);
+    let mut f = File::create(&batch_input_file_path).unwrap();
+    f.write_all(
+        test_json_content
+            .replace("__TABLE_NAME__", &table_name)
+            .as_bytes(),
+    )
+    .unwrap();
+
+    batch_input_file_path.to_str().unwrap().to_owned()
 }

--- a/tests/cmd/bwrite.md
+++ b/tests/cmd/bwrite.md
@@ -8,7 +8,7 @@ Put or Delete multiple items at one time, up to 25 requests. [API: BatchWriteIte
 https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
 
 USAGE:
-    dy bwrite [OPTIONS] --input <input>
+    dy bwrite [OPTIONS]
 
 FLAGS:
     -h, --help       
@@ -19,12 +19,19 @@ FLAGS:
 
 
 OPTIONS:
+        --del <dels>...      
+            The item to delete in Dynein format. Each item requires at least a primary key. Multiple items can be
+            specified by repeating the option. e.g. `--put '{Dynein format}' --put '{Dynein format}' --del '{Dynein
+            format}'`
     -i, --input <input>      
             Input JSON file path. This input file should be BatchWriteItem input JSON syntax. For more info:
             https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
     -p, --port <port>        
             Specify the port number. This option has an effect only when `--region local` is used
 
+        --put <puts>...      
+            The item to put in Dynein format. Each item requires at least a primary key. Multiple items can be specified
+            by repeating the option. e.g. `--put '{Dynein format}' --put '{Dynein format}' --del '{Dynein format}'`
     -r, --region <region>    
             The region to use (e.g. --region us-east-1). When using DynamodB Local, use `--region local`. You can use
             --region option in both top-level and subcommand-level
@@ -40,17 +47,23 @@ Put or Delete multiple items at one time, up to 25 requests. [API: BatchWriteIte
 https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
 
 USAGE:
-    dy bwrite [OPTIONS] --input <input>
+    dy bwrite [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
 OPTIONS:
+        --del <dels>...      The item to delete in Dynein format. Each item requires at least a primary key. Multiple
+                             items can be specified by repeating the option. e.g. `--put '{Dynein format}' --put
+                             '{Dynein format}' --del '{Dynein format}'`
     -i, --input <input>      Input JSON file path. This input file should be BatchWriteItem input JSON syntax. For more
                              info:
                              https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
     -p, --port <port>        Specify the port number. This option has an effect only when `--region local` is used
+        --put <puts>...      The item to put in Dynein format. Each item requires at least a primary key. Multiple items
+                             can be specified by repeating the option. e.g. `--put '{Dynein format}' --put '{Dynein
+                             format}' --del '{Dynein format}'`
     -r, --region <region>    The region to use (e.g. --region us-east-1). When using DynamodB Local, use `--region
                              local`. You can use --region option in both top-level and subcommand-level
     -t, --table <table>      Target table of the operation. You can use --table option in both top-level and subcommand-

--- a/tests/cmd_windows/bwrite.md
+++ b/tests/cmd_windows/bwrite.md
@@ -8,7 +8,7 @@ Put or Delete multiple items at one time, up to 25 requests. [API: BatchWriteIte
 https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
 
 USAGE:
-    dy[EXE] bwrite [OPTIONS] --input <input>
+    dy[EXE] bwrite [OPTIONS]
 
 FLAGS:
     -h, --help       
@@ -19,12 +19,19 @@ FLAGS:
 
 
 OPTIONS:
+        --del <dels>...      
+            The item to delete in Dynein format. Each item requires at least a primary key. Multiple items can be
+            specified by repeating the option. e.g. `--put '{Dynein format}' --put '{Dynein format}' --del '{Dynein
+            format}'`
     -i, --input <input>      
             Input JSON file path. This input file should be BatchWriteItem input JSON syntax. For more info:
             https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
     -p, --port <port>        
             Specify the port number. This option has an effect only when `--region local` is used
 
+        --put <puts>...      
+            The item to put in Dynein format. Each item requires at least a primary key. Multiple items can be specified
+            by repeating the option. e.g. `--put '{Dynein format}' --put '{Dynein format}' --del '{Dynein format}'`
     -r, --region <region>    
             The region to use (e.g. --region us-east-1). When using DynamodB Local, use `--region local`. You can use
             --region option in both top-level and subcommand-level
@@ -40,17 +47,23 @@ Put or Delete multiple items at one time, up to 25 requests. [API: BatchWriteIte
 https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
 
 USAGE:
-    dy[EXE] bwrite [OPTIONS] --input <input>
+    dy[EXE] bwrite [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
 OPTIONS:
+        --del <dels>...      The item to delete in Dynein format. Each item requires at least a primary key. Multiple
+                             items can be specified by repeating the option. e.g. `--put '{Dynein format}' --put
+                             '{Dynein format}' --del '{Dynein format}'`
     -i, --input <input>      Input JSON file path. This input file should be BatchWriteItem input JSON syntax. For more
                              info:
                              https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
     -p, --port <port>        Specify the port number. This option has an effect only when `--region local` is used
+        --put <puts>...      The item to put in Dynein format. Each item requires at least a primary key. Multiple items
+                             can be specified by repeating the option. e.g. `--put '{Dynein format}' --put '{Dynein
+                             format}' --del '{Dynein format}'`
     -r, --region <region>    The region to use (e.g. --region us-east-1). When using DynamodB Local, use `--region
                              local`. You can use --region option in both top-level and subcommand-level
     -t, --table <table>      Target table of the operation. You can use --table option in both top-level and subcommand-

--- a/tests/resources/test_batch_write_delete.json
+++ b/tests/resources/test_batch_write_delete.json
@@ -1,0 +1,21 @@
+{
+    "__TABLE_NAME__1": [
+        {
+            "DeleteRequest": {
+                "Key": {
+                    "pk": { "S": "ichi" }
+                }
+            }
+        }
+    ],
+    "__TABLE_NAME__2": [
+        {
+            "DeleteRequest": {
+                "Key": {
+                    "pk": { "S": "ichi" },
+                    "sk": { "S": "sortkey" }
+                }
+            }
+        }
+    ]
+}

--- a/tests/resources/test_batch_write_put.json
+++ b/tests/resources/test_batch_write_put.json
@@ -1,5 +1,5 @@
 {
-    "__TABLE_NAME__": [
+    "__TABLE_NAME__1": [
         {
             "PutRequest": {
                 "Item": {

--- a/tests/resources/test_batch_write_put_delete.json
+++ b/tests/resources/test_batch_write_put_delete.json
@@ -1,0 +1,25 @@
+{
+    "__TABLE_NAME__1": [
+        {
+            "PutRequest": {
+                "Item": {
+                    "pk": { "S": "ni" }
+                }
+            }
+        },
+        {
+            "PutRequest": {
+                "Item": {
+                    "pk": { "S": "san" }
+                }
+            }
+        },
+        {
+            "DeleteRequest": {
+                "Key": {
+                    "pk": { "S": "ichi" }
+                }
+            }
+        }
+    ]
+}

--- a/tests/resources/test_batch_write_put_delete_multiple_tables.json
+++ b/tests/resources/test_batch_write_put_delete_multiple_tables.json
@@ -1,0 +1,48 @@
+{
+    "__TABLE_NAME__1": [
+        {
+            "PutRequest": {
+                "Item": {
+                    "pk": { "S": "ni" }
+                }
+            }
+        },
+        {
+            "PutRequest": {
+                "Item": {
+                    "pk": { "S": "san" }
+                }
+            }
+        },
+        {
+            "DeleteRequest": {
+                "Key": {
+                    "pk": { "S": "ichi" }
+                }
+            }
+        }
+    ],
+    "__TABLE_NAME__2": [
+        {
+            "PutRequest": {
+                "Item": {
+                    "pk": { "S": "ni" }
+                }
+            }
+        },
+        {
+            "PutRequest": {
+                "Item": {
+                    "pk": { "S": "san" }
+                }
+            }
+        },
+        {
+            "DeleteRequest": {
+                "Key": {
+                    "pk": { "S": "ichi" }
+                }
+            }
+        }
+    ]
+}

--- a/tests/resources/test_batch_write_put_output.json
+++ b/tests/resources/test_batch_write_put_output.json
@@ -1,0 +1,32 @@
+[
+    {
+        "pk": { "S": "ichi" },
+        "ISBN": { "S": "111-1111111111" },
+        "Price": { "N": "2" },
+        "Dimensions": { "SS": ["Giraffe", "Hippo" ,"Zebra"] },
+        "PageCount": { "NS": ["42.2", "-19", "7.5", "3.14"] },
+        "InPublication": { "BOOL": false },
+        "Binary": {"B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"},
+        "BinarySet": {"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]},
+        "Nothing": { "NULL": true },
+        "Authors": {
+            "L": [
+                { "S": "Author1" },
+                { "S": "Author2" },
+                { "N": "42" }
+            ]
+        },
+        "Details": {
+            "M": {
+                "Name": { "S": "Joe" },
+                "Age":  { "N": "35" },
+                "Misc": {
+                    "M": {
+                        "hope": { "BOOL": true },
+                        "dream": { "L": [ { "N": "35" }, { "NULL": true } ] }
+                    }
+                }
+            }
+        }
+    }
+]


### PR DESCRIPTION
*Issue #, if available:*
#164

*Description of changes:*
Introduce new options into put command. This commit adds new command options, `--put` and `--del`.

```
dy bwrite --put '{Dynein format}' --put '{Dynein format}' --del '{Dynein format}'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
