### PR TITLE
chore: fix snapshot bot

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -44,17 +44,20 @@ jobs:
     - uses: actions/github-script@v6
       id: target-branch
       with:
-        result-encoding: string
+        result-encoding: json
         script: |
           const pull_request = await github.rest.pulls.get({
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: context.issue.number
           });
-          return pull_request.data.head.ref;
-    - uses: actions/checkout@v2
+          console.log("Target repo: " + pull_request.data.head.repo.full_name);
+          console.log("Target ref: " + pull_request.data.head.ref);
+          return { "repo": pull_request.data.head.repo.full_name, "ref": pull_request.data.head.ref };
+    - uses: actions/checkout@v4
       with:
-        ref: ${{ steps.target-branch.outputs.result }}
+        repository: ${{ fromJSON(steps.target-branch.outputs.result).repo }}
+        ref: ${{ fromJSON(steps.target-branch.outputs.result).ref }}
     - uses: actions-rs/toolchain@v1
       with:
         components: rustfmt, clippy
@@ -67,18 +70,60 @@ jobs:
       with:
         command: test
         args: cli_tests
-    - if: matrix.name == 'linux'
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git commit -am "test: update snapshot for ${{ matrix.name }}" || true
-        git push || true
-    - if: matrix.name == 'windows'
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git commit -am "test: update snapshot for ${{ matrix.name }}"
-        git push
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          // Create a diff and comment it on the pull request.
+          let stdOutput = '';
+          let errOutput = '';
+          
+          const options = {};
+          options.listeners = {
+            stdout: (data) => {
+              stdOutput += data.toString();
+            },
+            stderr: (data) => {
+              errOutput += data.toString();
+            }
+          };
+          
+          const code = await exec.exec('git', ['diff', '--patch', '--indent-heuristic'], options);
+          
+          // Output diff
+          if (stdOutput !== '') {
+            console.log("-- begin stdout --");
+            console.log(stdOutput);
+            console.log("-- end stdout --");
+          }
+          
+          // Output error
+          if (errOutput !== '') {
+            console.log("-- begin stderr --");
+            console.log(errOutput);
+            console.log("-- end stderr --");
+          }
+          
+          if (stdOutput !== '') {
+            console.log("There are differences. Creating a comment...");
+
+            const body = `You can apply a snapshot for ${{ matrix.name }} using \`git apply <diff-file>\`. The patch file is the following.
+          
+          <details>
+          <summary>git diff</summary>
+          
+          \`\`\`diff
+          ${stdOutput}
+          \`\`\`
+          </details>`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });
+          } else {
+            console.log("There are no differences. Skipping...");
+          }
   pr_post_comment:
     # This job only runs for pull request comments
     name: Comment after taking snapshots

--- a/README.md
+++ b/README.md
@@ -1238,8 +1238,15 @@ cargo test --test cli_tests
 Please note that we use different snapshots for the Windows environment.
 
 ### Bot
-If you want to update snapshots of commands, you can use bot command `/snapshot` in your pull request.
-Please note that you must type exactly as written.
+If you want to update snapshots of commands, you can use the bot command `/snapshot` in your pull request.
+Please note that you must type a command exactly as written.
+
+The bot creates diff files for both Windows and Linux. You can use generated diff to patch your commit.
+
+For example, if you have developed in a Linux environment and modified the command option,
+you must also update the snapshot for the Windows environment.
+In this case, you can create a pull request for draft mode and execute `/snapshot` to create a diff file for Windows.
+Generated diff can be copied into a file and applied by `git diff <file-name>` command.
 
 ## Asides
 


### PR DESCRIPTION
*Issue #, if available:*
Currently, the snapshot bot does not work correctly.
https://github.com/awslabs/dynein/actions/runs/6730473189.

*Description of changes:*
This pull request will fix the failure to generate a snapshot. Due to permission restriction, the bot only generates a diff. It means that the application of patches becomes the duty of requesters of pull requests.

The following is the example behavior of the bot.
https://github.com/StoneDot/dynein/pull/17#issuecomment-1794211433

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
