### PR TITLE
feat: add exponential backoff retry for ProvisionedThroughputExceeded / ThrottlingException / InternalServerError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "backon"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67782c3f868daa71d3533538e98a8e13713231969def7536e8039606fc46bf0"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +634,7 @@ name = "dynein"
 version = "0.2.1"
 dependencies = [
  "assert_cmd",
+ "backon",
  "base64 0.22.0",
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ console = "0.15.8"
 brotli = "5.0.0"
 base64 = "0.22.0"
 thiserror = "1.0.59"
+backon = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.14" # contains helpers make executing the main binary on integration tests easier.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -15,9 +15,10 @@
  */
 
 use crate::parser::DyneinParser;
+use backon::Retryable;
 use base64::{engine::general_purpose, Engine as _};
 use bytes::Bytes;
-use log::{debug, error};
+use log::{debug, error, warn};
 use rusoto_core::RusotoError;
 use rusoto_dynamodb::{
     AttributeValue, BatchWriteItemError, BatchWriteItemInput, DeleteRequest, DynamoDb,
@@ -226,7 +227,45 @@ async fn batch_write_item_api(
         ..Default::default()
     };
 
-    match ddb.batch_write_item(req).await {
+    let retry_setting = cx
+        .retry
+        .map(|v| v.batch_write_item.to_owned().unwrap_or(v.default));
+    let res = match retry_setting {
+        Some(backoff) => {
+            let f = || async { ddb.clone().batch_write_item(req.clone()).await };
+            f.retry(&backoff)
+                .when(|err| match err {
+                    RusotoError::Service(BatchWriteItemError::ProvisionedThroughputExceeded(e)) => {
+                        warn!("Retry batch_write_item : {}", e);
+                        true
+                    }
+                    RusotoError::Service(BatchWriteItemError::InternalServerError(e)) => {
+                        warn!("Retry batch_write_item : {}", e);
+                        true
+                    }
+                    RusotoError::Service(BatchWriteItemError::RequestLimitExceeded(e)) => {
+                        warn!("Retry batch_write_item : {}", e);
+                        true
+                    }
+                    RusotoError::HttpDispatch(e) => {
+                        warn!("Retry batch_write_item : {}", e);
+                        true
+                    }
+                    RusotoError::Unknown(response) => {
+                        if response.body_as_str().contains("ThrottlingException") {
+                            warn!("Retry batch_write_item : {}", err);
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                })
+                .await
+        }
+        None => ddb.batch_write_item(req).await,
+    };
+    match res {
         Ok(res) => Ok(res.unprocessed_items),
         Err(e) => Err(e),
     }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -64,6 +64,7 @@ using_table: null
 using_port: null
 query:
   strict_mode: false
+retry: null
 
 ",
     );
@@ -100,6 +101,7 @@ using_table: {table_name}
 using_port: 8000
 query:
   strict_mode: false
+retry: null
 
 "
     ));


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


add exponential backoff retry for ProvisionedThroughputExceeded / ThrottlingException / InternalServerError

*Issue #, if available:*
#195 

*Description of changes:*

Added the configuration to retry `batch_write_item_api`.

### Configuration 

Since `retry_batch_write_item` is optional, it can be undefined. 
In this case, no retry is performed.

dy config dump
```
---
tables: ~

---
using_region: ~
using_table: ~
using_port: ~
retry: ~
```

```
---
tables: ~

---
using_region: ~
using_table: ~
using_port: ~
retry:
  default:
    initial_backoff: ~
    max_backoff:
      secs: 10
      nanos: 0
    max_attempts: 20
  batch_write_item: ~
```

### Execution Logs

Output retry logs with warn level.

ProvisionedThroughputExceeded
```sh
9675 items processed (7.86 items/sec)[2024-02-20T06:49:02Z WARN  dy::batch] Retry batch_write_item : The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.
[2024-02-20T06:49:12Z WARN  dy::batch] Retry batch_write_item : The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.
9950 items processed (154.91 items/sec)[2024-02-20T06:49:34Z WARN  dy::batch] Retry batch_write_item : The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.
[2024-02-20T06:49:44Z WARN  dy::batch] Retry batch_write_item : The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.
10000 items processed (7.89 items/sec)
```

ThrottlingException
```
375 items processed (13.29 items/sec)[2024-02-27T00:51:18Z WARN  dy::batch] Retry batch_write_item : Request ID: Some("O3R1LLIR8E56GL9UA5N37HEV53VV4KQNSO5AEMVJF66Q9ASUAAJG") Body: {"__type":"com.amazon.coral.availability#ThrottlingException","message":"Throughput exceeds the current capacity of your table or index. DynamoDB is automatically scaling your table or index so please try again shortly. If exceptions persist, check if you have a hot key: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-partition-key-design.html"}
700 items processed (13.95 items/sec)[2024-02-27T00:51:54Z WARN  dy::batch] Retry batch_write_item : Request ID: Some("8TCT72BODCGFIKBVILA25P369RVV4KQNSO5AEMVJF66Q9ASUAAJG") Body: {"__type":"com.amazon.coral.availability#ThrottlingException","message":"Throughput exceeds the current capacity of your table or index. DynamoDB is automatically scaling your table or index so please try again shortly. If exceptions persist, check if you have a hot key: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-partition-key-design.html"}
750 items processed (8.45 items/sec)[2024-02-27T00:52:08Z WARN  dy::batch] Retry batch_write_item : Request ID: Some("5E6T40L360OAF6P4MFEE2S0RINVV4KQNSO5AEMVJF66Q9ASUAAJG") Body: {"__type":"com.amazon.coral.availability#ThrottlingException","message":"Throughput exceeds the current capacity of your table or index. DynamoDB is automatically scaling your table or index so please try again shortly. If exceptions persist, check if you have a hot key: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-partition-key-design.html"}

```

