### PR TITLE
refactor: remove atty dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,6 @@ name = "dynein"
 version = "0.2.1"
 dependencies = [
  "assert_cmd",
- "atty",
  "base64 0.21.7",
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ name = "dy"
 path = "src/main.rs"
 
 [dependencies]
-atty             = "0.2"
 chrono           = "0.4"
 dialoguer        = "0.10.4"
 dirs             = "4.0.0"

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -16,7 +16,7 @@
 
 use crate::cmd;
 use log::debug;
-use std::io::{stdout, BufRead, Stdin, StdinLock, Write};
+use std::io::{stdout, BufRead, IsTerminal, Stdin, StdinLock, Write};
 use std::{error::Error, io};
 
 /* =================================================
@@ -52,7 +52,7 @@ impl<'a> ShellReader<'a> {
     }
 
     pub fn read_line(&mut self) -> Result<ShellInput, Box<dyn Error>> {
-        if atty::is(atty::Stream::Stdin) {
+        if io::stdin().is_terminal() {
             print!("> ");
             stdout().flush().expect("failed to flush output");
         }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This pull request replaces the unmaintained `atty` with `std::io::IsTerminal.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
