### PR TITLE
chore: remove build-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,8 +606,6 @@ dependencies = [
  "termcolor",
  "tokio",
  "trycmd",
- "version_check",
- "yaml-rust",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,3 @@ predicates = "2.0.3" # to introduce advanced assertions
 once_cell = "1.9.0" # to setup docker container syncrhonously
 trycmd = "0.14.16" # snapshot testing for CLI
 rand = "0.8.5"
-
-[build-dependencies]
-# Unless the "version_check" build dependency, proc-macro-error-attr v1.0.4 build would fail.
-# To avoid it, we use v0.9.2 (latest as of 2020-11-21) to make sure Version::to_mmp func is public: https://github.com/SergioBenitez/version_check/commit/d9bd8e449
-version_check = "0.9.4"
-serde_yaml = "0.8.23"
-yaml-rust  = "0.4.3"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This pull request deletes `build-dependencies`, which is no longer necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
