### PR TITLE
test: add integration test for command aliases

### DIFF
--- a/tests/admin_desc.rs
+++ b/tests/admin_desc.rs
@@ -52,13 +52,15 @@ created_at: .*",
 #[tokio::test]
 async fn test_admin_desc_table_from_args() -> Result<(), Box<dyn std::error::Error>> {
     let mut tm = util::setup().await?;
-    let table_name = tm.create_temporary_table("pk,S", Some("sk,N")).await?;
 
-    let mut c = tm.command()?;
-    let cmd = c.args(["--region", "local", "admin", "desc", &table_name]);
-    cmd.assert().success().stdout(
-        predicate::str::is_match(format!(
-            "name: {}
+    for action in ["desc", "show", "describe", "info"] {
+        let table_name = tm.create_temporary_table("pk,S", Some("sk,N")).await?;
+
+        let mut c = tm.command()?;
+        let cmd = c.args(["--region", "local", "admin", action, &table_name]);
+        cmd.assert().success().stdout(
+            predicate::str::is_match(format!(
+                "name: {}
 region: local
 status: ACTIVE
 schema:
@@ -72,10 +74,12 @@ stream: null
 count: 0
 size_bytes: 0
 created_at: .*",
-            table_name
-        ))
-        .unwrap(),
-    );
+                table_name
+            ))
+            .unwrap(),
+        );
+    }
+
     Ok(())
 }
 

--- a/tests/del.rs
+++ b/tests/del.rs
@@ -56,30 +56,33 @@ async fn test_del_non_existent_item() -> Result<(), Box<dyn std::error::Error>> 
 #[tokio::test]
 async fn test_del_existent_item() -> Result<(), Box<dyn std::error::Error>> {
     let mut tm = util::setup().await?;
-    let table_name = tm
-        .create_temporary_table_with_items(
-            "pk",
-            None,
-            vec![
-                util::TemporaryItem::new("a", None, None),
-                util::TemporaryItem::new("b", None, None),
-            ],
-        )
-        .await?;
 
-    let mut c = tm.command()?;
-    let cmd = c.args(["--region", "local", "--table", &table_name, "del", "a"]);
-    cmd.assert().success().stdout(format!(
-        "Successfully deleted an item from the table '{}'.\n",
-        table_name
-    ));
+    for action in ["d", "del", "delete"] {
+        let table_name = tm
+            .create_temporary_table_with_items(
+                "pk",
+                None,
+                vec![
+                    util::TemporaryItem::new("a", None, None),
+                    util::TemporaryItem::new("b", None, None),
+                ],
+            )
+            .await?;
 
-    let mut c = tm.command()?;
-    let scan_cmd = c.args(["--region", "local", "--table", &table_name, "scan"]);
-    scan_cmd
-        .assert()
-        .success()
-        .stdout(predicate::str::diff("pk  attributes\nb\n"));
+        let mut c = tm.command()?;
+        let cmd = c.args(["--region", "local", "--table", &table_name, action, "a"]);
+        cmd.assert().success().stdout(format!(
+            "Successfully deleted an item from the table '{}'.\n",
+            table_name
+        ));
+
+        let mut c = tm.command()?;
+        let scan_cmd = c.args(["--region", "local", "--table", &table_name, "scan"]);
+        scan_cmd
+            .assert()
+            .success()
+            .stdout(predicate::str::diff("pk  attributes\nb\n"));
+    }
 
     Ok(())
 }

--- a/tests/desc.rs
+++ b/tests/desc.rs
@@ -42,13 +42,14 @@ async fn test_desc_non_existent_table() -> Result<(), Box<dyn std::error::Error>
 #[tokio::test]
 async fn test_desc_table_from_options() -> Result<(), Box<dyn std::error::Error>> {
     let mut tm = util::setup().await?;
-    let table_name = tm.create_temporary_table("pk,S", Some("sk,N")).await?;
 
-    let mut c = tm.command()?;
-    let cmd = c.args(["--region", "local", "--table", &table_name, "desc"]);
-    cmd.assert().success().stdout(
-        predicate::str::is_match(format!(
-            "name: {}
+    for action in ["show", "desc", "describe", "info"] {
+        let table_name = tm.create_temporary_table("pk,S", Some("sk,N")).await?;
+        let mut c = tm.command()?;
+        let cmd = c.args(["--region", "local", "--table", &table_name, action]);
+        cmd.assert().success().stdout(
+            predicate::str::is_match(format!(
+                "name: {}
 region: local
 status: ACTIVE
 schema:
@@ -62,10 +63,11 @@ stream: null
 count: 0
 size_bytes: 0
 created_at: .*",
-            table_name
-        ))
-        .unwrap(),
-    );
+                table_name
+            ))
+            .unwrap(),
+        );
+    }
 
     Ok(())
 }

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -55,17 +55,19 @@ async fn test_get_non_existent_item() -> Result<(), Box<dyn std::error::Error>> 
 #[tokio::test]
 async fn test_get_item() -> Result<(), Box<dyn std::error::Error>> {
     let mut tm = util::setup().await?;
-    let table_name = prepare_table_with_item(&mut tm).await?;
 
-    let mut c = tm.command()?;
-    let cmd = c.args(["--region", "local", "--table", &table_name, "get", "42"]);
-    util::assert_eq_cmd_json(
-        cmd,
-        r#"{
+    for action in ["get", "g"] {
+        let table_name = prepare_table_with_item(&mut tm).await?;
+        let mut c = tm.command()?;
+        let cmd = c.args(["--region", "local", "--table", &table_name, action, "42"]);
+        util::assert_eq_cmd_json(
+            cmd,
+            r#"{
           "flag": true,
           "pk": "42"
         }"#,
-    );
+        );
+    }
 
     Ok(())
 }

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -53,3 +53,21 @@ async fn test_list_table_with_multiple_tables() -> Result<(), Box<dyn std::error
         .stdout(predicate::str::contains(table_name2));
     Ok(())
 }
+
+#[tokio::test]
+async fn test_list_table_ls_alias() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tm = util::setup_with_lock().await?;
+    let table_name = tm.create_temporary_table("pk", None).await?;
+
+    let mut c = tm.command()?;
+    let cmd = c.args(["--region", "local", "use", &table_name]);
+    cmd.assert().success();
+
+    let mut c = tm.command()?;
+    let cmd = c.args(["--region", "local", "ls"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("DynamoDB tables in region: local"))
+        .stdout(predicate::str::contains(format!("* {table_name}")));
+    Ok(())
+}

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -24,25 +24,28 @@ use tokio::time::sleep; // Used for writing assertions
 #[tokio::test]
 async fn test_simple_query() -> Result<(), Box<dyn std::error::Error>> {
     let mut tm = util::setup().await?;
-    let table_name = tm
-        .create_temporary_table_with_items(
-            "pk",
-            Some("sk,N"),
-            vec![
-                util::TemporaryItem::new("abc", Some("1"), None),
-                util::TemporaryItem::new("abc", Some("2"), None),
-            ],
-        )
-        .await?;
 
-    let mut c = tm.command()?;
-    let query_cmd = c.args(["--region", "local", "--table", &table_name, "query", "abc"]);
-    query_cmd
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "pk   sk  attributes\nabc  1\nabc  2",
-        ));
+    for action in ["query", "q"] {
+        let table_name = tm
+            .create_temporary_table_with_items(
+                "pk",
+                Some("sk,N"),
+                vec![
+                    util::TemporaryItem::new("abc", Some("1"), None),
+                    util::TemporaryItem::new("abc", Some("2"), None),
+                ],
+            )
+            .await?;
+
+        let mut c = tm.command()?;
+        let query_cmd = c.args(["--region", "local", "--table", &table_name, action, "abc"]);
+        query_cmd
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "pk   sk  attributes\nabc  1\nabc  2",
+            ));
+    }
 
     Ok(())
 }

--- a/tests/scan.rs
+++ b/tests/scan.rs
@@ -59,18 +59,20 @@ async fn test_scan_blank_table() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn test_simple_scan() -> Result<(), Box<dyn std::error::Error>> {
     let mut tm = util::setup().await?;
-    let table_name = tm.create_temporary_table("pk", None).await?;
 
-    let mut c = tm.command()?;
-    c.args(["--region", "local", "--table", &table_name, "put", "abc"])
-        .output()?;
+    for action in ["scan", "s"] {
+        let table_name = tm.create_temporary_table("pk", None).await?;
+        let mut c = tm.command()?;
+        c.args(["--region", "local", "--table", &table_name, "put", "abc"])
+            .output()?;
 
-    let mut c = tm.command()?;
-    let scan_cmd = c.args(["--region", "local", "--table", &table_name, "scan"]);
-    scan_cmd
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("pk  attributes\nabc"));
+        let mut c = tm.command()?;
+        let scan_cmd = c.args(["--region", "local", "--table", &table_name, action]);
+        scan_cmd
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("pk  attributes\nabc"));
+    }
 
     Ok(())
 }

--- a/tests/upd.rs
+++ b/tests/upd.rs
@@ -23,76 +23,79 @@ pub mod util;
 #[tokio::test]
 async fn test_upd() -> Result<(), Box<dyn std::error::Error>> {
     let mut tm = util::setup().await?;
-    let tbl = tm.create_temporary_table("pk", None).await?;
-    tm.command()?
-        .args([
-            "--region",
-            "local",
-            "--table",
-            &tbl,
-            "upd",
-            "pk1",
-            "--set",
-            "attr1=123",
-        ])
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains("pk1")
-                .and(predicate::str::contains("attr1"))
-                .and(predicate::str::contains("123")),
-        );
 
-    let mut cmd = tm.command()?;
-    cmd.args(["--region", "local", "--table", &tbl, "get", "pk1"]);
-    assert_eq_cmd_json(&mut cmd, r#"{"pk":"pk1","attr1":123}"#);
+    for action in ["upd", "update", "u"] {
+        let tbl = tm.create_temporary_table("pk", None).await?;
+        tm.command()?
+            .args([
+                "--region",
+                "local",
+                "--table",
+                &tbl,
+                action,
+                "pk1",
+                "--set",
+                "attr1=123",
+            ])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("pk1")
+                    .and(predicate::str::contains("attr1"))
+                    .and(predicate::str::contains("123")),
+            );
 
-    tm.command()?
-        .args([
-            "--region",
-            "local",
-            "--table",
-            &tbl,
-            "upd",
-            "pk1",
-            "--set",
-            "attr2='str'",
-        ])
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains("pk1")
-                .and(predicate::str::contains("attr1"))
-                .and(predicate::str::contains("attr2"))
-                .and(predicate::str::contains("str")),
-        );
+        let mut cmd = tm.command()?;
+        cmd.args(["--region", "local", "--table", &tbl, "get", "pk1"]);
+        assert_eq_cmd_json(&mut cmd, r#"{"pk":"pk1","attr1":123}"#);
 
-    let mut cmd = tm.command()?;
-    cmd.args(["--region", "local", "--table", &tbl, "get", "pk1"]);
-    assert_eq_cmd_json(&mut cmd, r#"{"pk":"pk1","attr1":123,"attr2":"str"}"#);
+        tm.command()?
+            .args([
+                "--region",
+                "local",
+                "--table",
+                &tbl,
+                action,
+                "pk1",
+                "--set",
+                "attr2='str'",
+            ])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("pk1")
+                    .and(predicate::str::contains("attr1"))
+                    .and(predicate::str::contains("attr2"))
+                    .and(predicate::str::contains("str")),
+            );
 
-    tm.command()?
-        .args([
-            "--region",
-            "local",
-            "--table",
-            &tbl,
-            "upd",
-            "pk1",
-            "--remove",
-            "attr1,attr2",
-        ])
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains("pk1")
-                .and(predicate::str::contains("attr1").not())
-                .and(predicate::str::contains("attr2").not()),
-        );
+        let mut cmd = tm.command()?;
+        cmd.args(["--region", "local", "--table", &tbl, "get", "pk1"]);
+        assert_eq_cmd_json(&mut cmd, r#"{"pk":"pk1","attr1":123,"attr2":"str"}"#);
 
-    let mut cmd = tm.command()?;
-    cmd.args(["--region", "local", "--table", &tbl, "get", "pk1"]);
-    assert_eq_cmd_json(&mut cmd, r#"{"pk":"pk1"}"#);
+        tm.command()?
+            .args([
+                "--region",
+                "local",
+                "--table",
+                &tbl,
+                action,
+                "pk1",
+                "--remove",
+                "attr1,attr2",
+            ])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("pk1")
+                    .and(predicate::str::contains("attr1").not())
+                    .and(predicate::str::contains("attr2").not()),
+            );
+
+        let mut cmd = tm.command()?;
+        cmd.args(["--region", "local", "--table", &tbl, "get", "pk1"]);
+        assert_eq_cmd_json(&mut cmd, r#"{"pk":"pk1"}"#);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
*Issue #, if available:*
Related to #143

*Description of changes:*
This pull request adds tests for command aliases, `dy info`, `dy q`, and so on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
