### PR TITLE
chore!: change a dependency from dirs to home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,27 +913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,9 +952,9 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
- "dirs",
  "env_logger",
  "futures",
+ "home",
  "itertools",
  "log",
  "once_cell",
@@ -1319,6 +1298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,16 +1596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.5.0",
- "libc",
-]
-
-[[package]]
 name = "libz-ng-sys"
 version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,12 +1791,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_pipe"
@@ -2084,17 +2056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
  "bitflags 2.5.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ aws-smithy-types = "1.1.9"
 chrono           = "0.4"
 clap = { version = "4.5.4", features = ["derive"] }
 dialoguer        = "0.11.0"
-dirs             = "5.0.1"
 env_logger       = "0.11.3"
 futures          = "0.3.30"
 log              = "0.4.21"
@@ -60,6 +59,7 @@ console = "0.15.8"
 brotli = "6.0.0"
 base64 = "0.22.0"
 thiserror = "1.0.59"
+home = "0.5.9"
 
 [dev-dependencies]
 assert_cmd = "2.0.14" # contains helpers make executing the main binary on integration tests easier.

--- a/src/app.rs
+++ b/src/app.rs
@@ -700,7 +700,7 @@ fn retrieve_dynein_file_path(file_type: DyneinFileType) -> Result<String, Dynein
 
 fn retrieve_or_create_dynein_dir() -> Result<String, DyneinConfigError> {
     let full_path = env::var(CONFIG_PATH_ENV_VAR_NAME).unwrap_or(
-        dirs::home_dir()
+        home::home_dir()
             .ok_or(DyneinConfigError::HomeDir)?
             .to_str()
             .ok_or(DyneinConfigError::HomeDir)?


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This pull request changes a dependency from `dirs` to `home`. Currently, `dirs` is an overkill crate for our project.
This is breaking change because two crates provide different behavior.

* https://docs.rs/dirs/latest/dirs/fn.home_dir.html
* https://docs.rs/home/latest/home/fn.home_dir.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
