### PR TITLE
feat: add -y as short yes to delete table

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -550,7 +550,7 @@ pub enum DeleteSub {
         table_name_to_delete: String,
 
         /// Skip interactive confirmation before deleting a table.
-        #[clap(long, verbatim_doc_comment)]
+        #[clap(short, long, verbatim_doc_comment)]
         yes: bool,
     },
     // #[clap(verbatim_doc_comment)]

--- a/tests/cmd/admin.md
+++ b/tests/cmd/admin.md
@@ -144,7 +144,7 @@ Arguments:
   <TABLE_NAME_TO_DELETE>  table name to delete
 
 Options:
-      --yes              Skip interactive confirmation before deleting a table.
+  -y, --yes              Skip interactive confirmation before deleting a table.
   -r, --region <REGION>  The region to use (e.g. --region us-east-1). When using DynamodB Local, use `--region local`.
                          You can use --region option in both top-level and subcommand-level.
   -p, --port <PORT>      Specify the port number. This option has an effect only when `--region local` is used.

--- a/tests/cmd_windows/admin.md
+++ b/tests/cmd_windows/admin.md
@@ -144,7 +144,7 @@ Arguments:
   <TABLE_NAME_TO_DELETE>  table name to delete
 
 Options:
-      --yes              Skip interactive confirmation before deleting a table.
+  -y, --yes              Skip interactive confirmation before deleting a table.
   -r, --region <REGION>  The region to use (e.g. --region us-east-1). When using DynamodB Local, use `--region local`.
                          You can use --region option in both top-level and subcommand-level.
   -p, --port <PORT>      Specify the port number. This option has an effect only when `--region local` is used.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

We provide `-y` to delete table for usability. A lot of CLI provide `-y` or `--yes` to get confirmation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
