### PR TITLE
fix(export): empty array is on one line fix #152

### DIFF
--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -475,7 +475,8 @@ fn filter_attributes_to_append(ts: &app::TableSchema, ats: String) -> Vec<String
 fn connectable_json(mut s: String, compact: bool) -> String {
     s.remove(0); // remove first char "["
     let len = s.len();
-    if compact {
+    if compact || len == 1 {
+        // empty array even if not compact is on one line
         s.truncate(len - 1); // remove last char "]"
     } else {
         s.truncate(len - 2); // remove last char "]" and newline

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -59,11 +59,7 @@ async fn test_export_empty_table() -> Result<(), Box<dyn std::error::Error>> {
         "--output-file",
         temp_path.to_str().unwrap(),
     ]);
-    // TODO: this behavior should be fixed by the issue
-    // https://github.com/awslabs/dynein/issues/152
-    cmd.assert().failure().stderr(predicate::str::contains(
-        "thread 'main' panicked at src/transfer.rs:481:20:\nattempt to subtract with overflow",
-    ));
+    cmd.assert().success();
     Ok(())
 }
 


### PR DESCRIPTION
*Issue #152*

Empty array in function `connectable_json` came on one line even not in compact format.
This PR tests this case and act acordingly 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
