### PR TITLE
chore: handle SdkError to show error message

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,8 @@ use aws_config::{
     meta::region::RegionProviderChain, retry::RetryConfig, BehaviorVersion, Region, SdkConfig,
 };
 use aws_sdk_dynamodb::types::{AttributeDefinition, TableDescription};
+use aws_smithy_runtime_api::client::result::SdkError;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use log::{debug, error, info};
 use serde_yaml::Error as SerdeYAMLError;
 use std::convert::{TryFrom, TryInto};
@@ -682,6 +684,18 @@ pub fn index_schemas(desc: &TableDescription) -> Option<Vec<IndexSchema>> {
 
 pub fn bye(code: i32, msg: &str) -> ! {
     println!("{}", msg);
+    std::process::exit(code);
+}
+
+pub fn bye_with_sdk_error<E, R>(code: i32, error: SdkError<E, R>) -> !
+where
+    E: fmt::Debug + ProvideErrorMetadata,
+    R: fmt::Debug,
+{
+    match error.as_service_error() {
+        Some(service_error) => error!("service error occurred: {:?}", service_error.meta()),
+        None => error!("an error occurred: {:?}", error),
+    };
     std::process::exit(code);
 }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -26,7 +26,7 @@ use aws_sdk_dynamodb::{
     types::{AttributeValue, PutRequest, WriteRequest},
 };
 use futures::future::join_all;
-use log::{debug, error};
+use log::debug;
 
 use brotli::Decompressor;
 use serde_json::Value as JsonValue;
@@ -303,16 +303,15 @@ async fn prepare_table(cx: &app::Context, table_name: &str, keys: &[&str]) {
                 desc.table_status.unwrap()
             );
         }
-        Err(e) => match e.into_service_error() {
-            CreateTableError::ResourceInUseException(_) => println!(
+        Err(e) => match e.as_service_error() {
+            Some(CreateTableError::ResourceInUseException(_)) => println!(
                 "[skip] Table '{}' already exists in {} region, skipping to create new one.",
                 table_name,
                 cx.effective_region().await.as_ref()
             ),
-            e => {
+            _ => {
                 debug!("CreateTable API call got an error -- {:#?}", e);
-                error!("{}", e.to_string());
-                std::process::exit(1);
+                app::bye_with_sdk_error(1, e);
             }
         },
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -190,8 +190,7 @@ pub async fn scan_api(
         .await
         .unwrap_or_else(|e| {
             debug!("Scan API call got an error -- {:?}", e);
-            error!("{}", e.to_string());
-            std::process::exit(1);
+            app::bye_with_sdk_error(1, e);
         })
 }
 
@@ -274,8 +273,7 @@ pub async fn query(cx: &app::Context, params: QueryParams) {
         }
         Err(e) => {
             debug!("Query API call got an error -- {:?}", e);
-            error!("{}", e.to_string());
-            std::process::exit(1);
+            app::bye_with_sdk_error(1, e);
         }
     }
 }
@@ -331,8 +329,7 @@ pub async fn get_item(
         },
         Err(e) => {
             debug!("GetItem API call got an error -- {:?}", e);
-            error!("{}", e.to_string());
-            std::process::exit(1);
+            app::bye_with_sdk_error(1, e);
         }
     }
 }
@@ -384,8 +381,7 @@ pub async fn put_item(cx: &app::Context, pval: String, sval: Option<String>, ite
         }
         Err(e) => {
             debug!("PutItem API call got an error -- {:?}", e);
-            error!("{}", e.into_service_error().meta());
-            std::process::exit(1);
+            app::bye_with_sdk_error(1, e);
         }
     }
 }
@@ -420,8 +416,7 @@ pub async fn delete_item(cx: &app::Context, pval: String, sval: Option<String>) 
         }
         Err(e) => {
             debug!("Deletetem API call got an error -- {:?}", e);
-            error!("{}", e.to_string());
-            std::process::exit(1);
+            app::bye_with_sdk_error(1, e);
         }
     }
 }
@@ -481,8 +476,7 @@ pub async fn update_item(
         }
         Err(e) => {
             debug!("UpdateItem API call got an error -- {:?}", e);
-            error!("{}", e.to_string());
-            std::process::exit(1);
+            app::bye_with_sdk_error(1, e);
         }
     }
 }

--- a/tests/backup.rs
+++ b/tests/backup.rs
@@ -32,13 +32,14 @@ async fn test_backup() -> Result<(), Box<dyn std::error::Error>> {
             "To execute the command you must specify target table in one of following ways:",
         ));
 
+    // This error message only happens on DynamoDB Local which does not support backup feature.
     tm.command()?
         .args(["-r", "local", "backup", "--table", "non-existent-table"])
         .assert()
         .failure()
-        .stdout(predicate::str::contains(
-            // This error message only happens on DynamoDB Local which does not support backup feature.
-            "unhandled error (UnknownOperationException)",
+        .stderr(predicate::str::contains("UnknownOperationException"))
+        .stderr(predicate::str::contains(
+            "An unknown operation was requested.",
         ));
 
     Ok(())

--- a/tests/restore.rs
+++ b/tests/restore.rs
@@ -32,13 +32,14 @@ async fn test_restore() -> Result<(), Box<dyn std::error::Error>> {
             "To execute the command you must specify target table in one of following ways:",
         ));
 
+    // This error message only happens on DynamoDB Local which does not support backup feature.
     tm.command()?
         .args(["-r", "local", "restore", "--table", "non-existent-table"])
         .assert()
         .failure()
-        .stdout(predicate::str::contains(
-            // This error message only happens on DynamoDB Local which does not support backup feature.
-            "unhandled error (UnknownOperationException)",
+        .stderr(predicate::str::contains("UnknownOperationException"))
+        .stderr(predicate::str::contains(
+            "An unknown operation was requested.",
         ));
 
     Ok(())


### PR DESCRIPTION
*Issue #, if available:*

fix #247. In this PR, we introduce useful error message.

```rust
[2024-06-17T15:29:52Z ERROR dy::control] service error occurred: ErrorMetadata { code: Some("ValidationException"), message: Some("1 validation error detected: Value 'a' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3"), extras: Some({"aws_request_id": "xxx"}) }
```

```rust
[2024-06-17T15:28:16Z ERROR dy::control] an error occurred: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InvalidConfiguration(InvalidConfiguration { source: "ProfileFile provider could not be built: profile `a` was not defined: could not find source profile a referenced from the root profile" }), connection: Unknown } })
```

Best way to show human readable message is to use original error but we cannot retrieve it as mentioned in https://github.com/awslabs/aws-sdk-rust/discussions/1076. So we show rust error code instead.

*Description of changes:*

We can imagine some patters to handle SdkError to show error message.

1. Use fmt in `SdkError`

This pattern is easy to handle the error but it won't give us useful information.

```rust
error!("{}", e);
```

```rust
[2024-06-17T14:23:19Z ERROR dy::control] service error
```

2. Use debug from `SdkError`

It will give us useful information but a lot of informations is shown so we are hard to understand shortly what the issue occur. Also detailed informations are covered by debug message.  

```rust
error!("{:?}", e);
``` 

```rust
[2024-06-17T14:24:21Z ERROR dy::control] ServiceError(ServiceError { source: Unhandled(Unhandled { source: ErrorMetadata { code: Some("ValidationException"), message: Some("1 validation error detected: Value 'a' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3"), extras: Some({"aws_request_id": "xxx"}) }, meta: ErrorMetadata { code: Some("ValidationException"), message: Some("1 validation error detected: Value 'a' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3"), extras: Some({"aws_request_id": "xxx"}) } }), raw: Response { status: StatusCode(400), headers: Headers { headers: {"server": HeaderValue { _private: H0("Server") }, "date": HeaderValue { _private: H0("Mon, 17 Jun 2024 14:24:21 GMT") }, "content-type": HeaderValue { _private: H0("application/x-amz-json-1.0") }, "content-length": HeaderValue { _private: H0("205") }, "connection": HeaderValue { _private: H0("keep-alive") }, "x-amzn-requestid": HeaderValue { _private: H0("xxx") }, "x-amz-crc32": HeaderValue { _private: H0("540347094") }} }, body: SdkBody { inner: Once(Some(b"{\"__type\":\"com.amazon.coral.validate#ValidationException\",\"message\":\"1 validation error detected: Value 'a' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3\"}")), retryable: true }, extensions: Extensions { extensions_02x: Extensions, extensions_1x: Extensions } } })
```

3. Use `meta()` from `ServiceError`

It will give us enough informations but we need to consider other error such as `DispatchFailure`.

```rust
error!("{}", e.into_service_error().meta());
```

```rust
[2024-06-17T14:29:55Z ERROR dy::control] Error { code: "ValidationException", message: "1 validation error detected: Value 'a' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3", aws_request_id: "xxx" }
```

While `DispatchFailure` occur, we just got `Error`.

```rust
[2024-06-17T14:40:15Z ERROR dy::control] Error
```

4. Use `meta()` from `ServiceError` and use debug from other error

As mentioned, if we use debug message, a lot of informations is shown. As for other error, it will give us enough informations.

```rust
[2024-06-17T14:41:48Z ERROR dy::control] DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InvalidConfiguration(InvalidConfiguration { source: "ProfileFile provider could not be built: profile `a` was not defined: could not find source profile a referenced from the root profile" }), connection: Unknown } })
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
