### PR TITLE
chore: update bytes to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,9 +581,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "bytes-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ termcolor        = "1.4.1"
 tokio = { version = "1.37.0", features = ["full"] }
 pest = "2.7.10"
 pest_derive = "2.7.10"
-bytes = "1.6.0"
+bytes = "1.6.1"
 itertools = "0.13.0"
 console = "0.15.8"
 brotli = "6.0.0"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

bytes for 1.6.0 is yanked.
https://crates.io/crates/bytes/1.6.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
