### PR TITLE
test: remove unnecessary vec! from create_temporary_table_with_items

### DIFF
--- a/tests/bwrite.rs
+++ b/tests/bwrite.rs
@@ -75,7 +75,7 @@ async fn test_batch_write_json_delete() -> Result<(), Box<dyn std::error::Error>
         .create_temporary_table_with_items(
             "pk",
             None,
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "ichi",
                 None,
                 Some(r#"{"null-field": null}"#),
@@ -87,7 +87,7 @@ async fn test_batch_write_json_delete() -> Result<(), Box<dyn std::error::Error>
         .create_temporary_table_with_items(
             "pk",
             Some("sk"),
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "ichi",
                 Some("sortkey"),
                 Some(r#"{"null-field": null}"#),
@@ -147,7 +147,7 @@ async fn test_batch_write_json_put_delete() -> Result<(), Box<dyn std::error::Er
         .create_temporary_table_with_items(
             "pk",
             None,
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "ichi",
                 None,
                 Some(r#"{"null-field": null}"#),
@@ -198,7 +198,7 @@ async fn test_batch_write_json_put_delete_multiple_tables() -> Result<(), Box<dy
         .create_temporary_table_with_items(
             "pk",
             None,
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "ichi",
                 None,
                 Some(r#"{"null-field": null}"#),
@@ -210,7 +210,7 @@ async fn test_batch_write_json_put_delete_multiple_tables() -> Result<(), Box<dy
         .create_temporary_table_with_items(
             "pk",
             None,
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "ichi",
                 None,
                 Some(r#"{"null-field": null}"#),
@@ -356,7 +356,7 @@ async fn test_batch_write_del() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             None,
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "11",
                 None,
                 Some(r#"{"null-field": null}"#),
@@ -399,7 +399,7 @@ async fn test_batch_write_del_sk() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk"),
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "11",
                 Some("111"),
                 Some(r#"{"null-field": null}"#),
@@ -442,7 +442,7 @@ async fn test_batch_write_all_options() -> Result<(), Box<dyn std::error::Error>
         .create_temporary_table_with_items(
             "pk",
             None,
-            vec![
+            [
                 util::TemporaryItem::new("11", None, Some(r#"{"null-field": null}"#)),
                 util::TemporaryItem::new("ichi", None, Some(r#"{"null-field": null}"#)),
             ],

--- a/tests/del.rs
+++ b/tests/del.rs
@@ -62,7 +62,7 @@ async fn test_del_existent_item() -> Result<(), Box<dyn std::error::Error>> {
             .create_temporary_table_with_items(
                 "pk",
                 None,
-                vec![
+                [
                     util::TemporaryItem::new("a", None, None),
                     util::TemporaryItem::new("b", None, None),
                 ],
@@ -94,7 +94,7 @@ async fn test_del_existent_item_with_sk() -> Result<(), Box<dyn std::error::Erro
         .create_temporary_table_with_items(
             "pk,S",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("2"), None),
                 util::TemporaryItem::new("abc", Some("3"), None),

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -70,7 +70,7 @@ async fn test_export_with_items() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("2"), Some(r#"{"a": 1, "b": 2}"#)),
                 util::TemporaryItem::new("def", Some("3"), None),

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -164,7 +164,7 @@ async fn prepare_table_with_item<'a>(
         .create_temporary_table_with_items(
             "pk",
             None,
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "42",
                 None,
                 Some("{\"flag\": true}"),

--- a/tests/put.rs
+++ b/tests/put.rs
@@ -319,7 +319,7 @@ async fn test_put_same_pk() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             None,
-            vec![util::TemporaryItem::new(
+            [util::TemporaryItem::new(
                 "42",
                 None,
                 Some(r#"{"null-field": null}"#),

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -30,7 +30,7 @@ async fn test_simple_query() -> Result<(), Box<dyn std::error::Error>> {
             .create_temporary_table_with_items(
                 "pk",
                 Some("sk,N"),
-                vec![
+                [
                     util::TemporaryItem::new("abc", Some("1"), None),
                     util::TemporaryItem::new("abc", Some("2"), None),
                 ],
@@ -57,7 +57,7 @@ async fn test_simple_desc_query() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("2"), None),
             ],
@@ -91,7 +91,7 @@ async fn test_query_limit() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("2"), None),
             ],
@@ -124,7 +124,7 @@ async fn test_query_with_sort_key() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("2"), None),
                 util::TemporaryItem::new("abc", Some("3"), None),
@@ -161,7 +161,7 @@ async fn test_query_with_keys_only() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), Some("{'opt':'A'}")),
                 util::TemporaryItem::new("abc", Some("2"), Some("{'opt':'B'}")),
                 util::TemporaryItem::new("abc", Some("3"), Some("{'opt':'C'}")),
@@ -197,7 +197,7 @@ async fn test_query_with_attributes() -> Result<(), Box<dyn std::error::Error>> 
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), Some("{'opt1':'1','opt2':'1'}")),
                 util::TemporaryItem::new("abc", Some("2"), Some("{'opt1':'2','opt2':'2'}")),
                 util::TemporaryItem::new("abc", Some("3"), Some("{'opt1':'3','opt2':'3'}")),
@@ -232,7 +232,7 @@ async fn test_query_for_index() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), Some("{'gsi':'1'}")),
                 util::TemporaryItem::new("abc", Some("2"), Some("{'gsi':'2'}")),
                 util::TemporaryItem::new("abc", Some("3"), Some("{'gsi':'3'}")),
@@ -285,7 +285,7 @@ async fn test_query_with_sort_key_order() -> Result<(), Box<dyn std::error::Erro
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("2"), None),
                 util::TemporaryItem::new("abc", Some("3"), None),
@@ -320,7 +320,7 @@ async fn test_query_with_sort_key_le() -> Result<(), Box<dyn std::error::Error>>
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("2"), None),
                 util::TemporaryItem::new("abc", Some("3"), None),
@@ -357,7 +357,7 @@ async fn test_query_using_between_string() -> Result<(), Box<dyn std::error::Err
         .create_temporary_table_with_items(
             "pk",
             Some("sk,S"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("11"), None),
                 util::TemporaryItem::new("abc", Some("2"), None),
@@ -397,7 +397,7 @@ async fn test_query_using_between_number() -> Result<(), Box<dyn std::error::Err
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("11"), None),
                 util::TemporaryItem::new("abc", Some("2"), None),
@@ -437,7 +437,7 @@ async fn test_query_using_begins_with() -> Result<(), Box<dyn std::error::Error>
         .create_temporary_table_with_items(
             "pk",
             Some("sk,S"),
-            vec![
+            [
                 util::TemporaryItem::new("abc", Some("1"), None),
                 util::TemporaryItem::new("abc", Some("11"), None),
                 util::TemporaryItem::new("abc", Some("21"), None),
@@ -475,7 +475,7 @@ async fn test_query_non_strict() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![util::TemporaryItem::new("abc", Some("1100"), None)],
+            [util::TemporaryItem::new("abc", Some("1100"), None)],
         )
         .await?;
 
@@ -505,7 +505,7 @@ async fn test_query_invalid_input() -> Result<(), Box<dyn std::error::Error>> {
         .create_temporary_table_with_items(
             "pk",
             Some("sk,S"),
-            vec![util::TemporaryItem::new("abc", Some("2"), None)],
+            [util::TemporaryItem::new("abc", Some("2"), None)],
         )
         .await?;
 
@@ -534,7 +534,7 @@ async fn test_query_with_strict_mode_with_suggestion() -> Result<(), Box<dyn std
         .create_temporary_table_with_items(
             "pk",
             Some("sk,S"),
-            vec![util::TemporaryItem::new("abc", Some("2"), None)],
+            [util::TemporaryItem::new("abc", Some("2"), None)],
         )
         .await?;
 
@@ -567,7 +567,7 @@ async fn test_query_with_strict_mode_without_suggestion() -> Result<(), Box<dyn 
         .create_temporary_table_with_items(
             "pk",
             Some("sk,N"),
-            vec![util::TemporaryItem::new("abc", Some("8"), None)],
+            [util::TemporaryItem::new("abc", Some("8"), None)],
         )
         .await?;
 
@@ -599,7 +599,7 @@ async fn test_query_with_strict_config() -> Result<(), Box<dyn std::error::Error
         .create_temporary_table_with_items(
             "pk",
             Some("sk,S"),
-            vec![util::TemporaryItem::new("abc", Some("2"), None)],
+            [util::TemporaryItem::new("abc", Some("2"), None)],
         )
         .await?;
     let mut c = tm.command_with_envs(
@@ -640,7 +640,7 @@ async fn test_query_overriding_with_non_strict_config() -> Result<(), Box<dyn st
         .create_temporary_table_with_items(
             "pk",
             Some("sk,S"),
-            vec![util::TemporaryItem::new("abc", Some("2"), None)],
+            [util::TemporaryItem::new("abc", Some("2"), None)],
         )
         .await?;
     let mut c = tm.command_with_envs(

--- a/tests/use.rs
+++ b/tests/use.rs
@@ -126,7 +126,7 @@ async fn test_use_switch() -> Result<(), Box<dyn std::error::Error>> {
             .create_temporary_table_with_items(
                 "pk1",
                 None,
-                vec![
+                [
                     util::TemporaryItem::new("v1", None, None),
                     util::TemporaryItem::new("v2", None, None),
                 ],
@@ -136,7 +136,7 @@ async fn test_use_switch() -> Result<(), Box<dyn std::error::Error>> {
             .create_temporary_table_with_items(
                 "pk2",
                 None,
-                vec![
+                [
                     util::TemporaryItem::new("v3", None, None),
                     util::TemporaryItem::new("v4", None, None),
                 ],


### PR DESCRIPTION
*Issue #, if available:*
#238 

*Description of changes:*
This PR addresses the issue raised in #238 by removing the unnecessary use of `vec!` macro when calling　`create_temporary_table_with_items`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
