### PR TITLE
test: use dummy credential when executing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
       RUST_LOG: debug # Output debug log
       RUST_BACKTRACE: 1 # Dump backtrace on panic
       DYNEIN_TEST_NO_DOCKER_SETUP: true
-      # define AWS credentials in environment for test
-      AWS_ACCESS_KEY_ID: test
-      AWS_SECRET_ACCESS_KEY: test
     services:
       dynamodb:
         # Pinned to the version not to be broken with latest
@@ -54,9 +51,6 @@ jobs:
       RUST_LOG: debug # Output debug log
       RUST_BACKTRACE: 1 # Dump backtrace on panic
       DYNEIN_TEST_NO_DOCKER_SETUP: true
-      # define AWS credentials in environment for test
-      AWS_ACCESS_KEY_ID: test
-      AWS_SECRET_ACCESS_KEY: test
     steps:
     - uses: actions/checkout@v4
     - name: Install rust toolchain

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -72,7 +72,11 @@ impl<'a> TestManager<'a> {
 
     pub fn command(&self) -> Result<Command, Box<dyn std::error::Error>> {
         let mut c = Command::cargo_bin("dy")?;
-        c.env("DYNEIN_CONFIG_DIR", &self.default_config_dir);
+        c.envs([
+            ("DYNEIN_CONFIG_DIR", &self.default_config_dir),
+            ("AWS_ACCESS_KEY_ID", &PathBuf::from("test")),
+            ("AWS_SECRET_ACCESS_KEY", &PathBuf::from("test")),
+        ]);
         Ok(c)
     }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Currently, the `cargo test` command uses a default credential chain to determine an AWS credential. However, it should use a dummy credential instead because an actual credential may change the production environment. Switching the default credential to a dummy credential also mitigates the pain when executing a `cargo test` that may require setting `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
