### PR TITLE
  docs: clarify purpose of dy scan command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ DynamoDB tables in region: us-east-2
 
 Here `--all-regions` option enables you to iterate over all AWS regions and list all tables for you.
 
-Next you can try `dy scan` with region and table options. `dy scan` command executes [Scan API](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html) internally to retrieve all items in the table.
+Next you can try `dy scan` with region and table options. `dy scan` command executes [Scan API](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html) internally with a default limit. To retrieve all items from a table, use `dy import` command.
 
 ```
 $ dy scan --region us-west-2 --table Forum
@@ -459,7 +459,7 @@ To make it easy to interact with DynamoDB items, dynein automatically replace re
 
 #### `dy scan`
 
-The simplest command would be `dy scan`, which list items in a table.
+The simplest command would be `dy scan`, which list items in a table with a default limit. You can specify the maximum number of items to scan using the `--limit` option.
 
 ```
 $ dy scan --limit 10


### PR DESCRIPTION
  Update documentation to clarify that:
  - dy scan executes Scan API with a default limit for inspecting/sampling items
  - dy import should be used to retrieve all items from a table
  - --limit option specifies the maximum number of items to scan

  This addresses confusion about the difference between dy scan (for sampling)
  and dy import (for retrieving all items).

  Fixes #280

*Issue #, if available:*
#280

*Description of changes:*
The previous documentation suggested that `dy scan` retrieves "all items in the table," which could lead users to
expect it behaves like `dy import`. This update makes it clear that:
- `dy scan` is intended for **inspecting/sampling** table items (to see what typical items look like)
- `dy import` is intended for **retrieving all items** from a table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
